### PR TITLE
Fixes issue where selected text couldn't be replaced on the example page

### DIFF
--- a/output/example/index.js
+++ b/output/example/index.js
@@ -52,9 +52,10 @@ let ui = (function () {
 
   that.commitString = function (string) {
     var selectionStart = document.getElementById("text_area").selectionStart;
+    var selectionEnd = document.getElementById("text_area").selectionEnd;
     var text = document.getElementById("text_area").value;
     var head = text.substring(0, selectionStart);
-    var tail = text.substring(selectionStart);
+    var tail = text.substring(selectionEnd);
     document.getElementById("text_area").value = head + string + tail;
     let start = selectionStart + string.length;
     document.getElementById("text_area").setSelectionRange(start, start);


### PR DESCRIPTION
The action of entering text after selecting should be implemented as replacement, as it would be closer to the typical input method behavior.

Before:
<img src="https://github.com/openvanilla/McBopomofoWeb/assets/36815907/2891aea8-c002-4d30-8098-3d77a418cb71" width="350">

After:
<img src="https://github.com/openvanilla/McBopomofoWeb/assets/36815907/4e9d878e-aeb4-4f83-b10f-79ef4080ab47" width="350">
