### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/output/pime/config_tool.py
+++ b/output/pime/config_tool.py
@@ -5,7 +5,9 @@ import os
 import uuid  # use to generate a random auth token
 import random
 import json
+import logging
 
+logging.basicConfig(level=logging.INFO)
 current_dir = os.path.dirname(__file__)
 
 config_dir = os.path.join(os.path.expandvars("%APPDATA%"), "PIME", "mcbopomofo")
@@ -130,8 +132,8 @@ class UserPhrasesHandler(BaseHandler):
                 f.write(data)
             self.write('{"return":true}')
         except Exception as e:
-            print(e)
-            self.write('{"return":false, "error":"%s"}' % str(e))
+            logging.error("Error saving user phrases: %s", e, exc_info=True)
+            self.write('{"return":false, "error":"An internal error has occurred."}')
 
 
 class ExcludedPhrasesHandler(BaseHandler):


### PR DESCRIPTION
Potential fix for [https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/9](https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/9)

To fix the issue, we should avoid sending the raw exception message back to the external user. Instead, log the exception server-side (for diagnostics) and return a generic error message in the HTTP response. 

- In output/pime/config_tool.py, within the `UserPhrasesHandler.post` method (lines 132-134), replace the code that prints and returns the exception string with code that logs the exception (using Python's `logging` module) and returns a generic error message to the user.
- Add an import for the `logging` module at the top of the file if not already present.
- Set up a default logger if not already set.
- Only the external response should change; no changes are made to exception handling logic or application functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
