### PR TITLE
Refactor CSS: Optimize light theme for E-ink, standardize dark theme.

### DIFF
--- a/output/example/index.css
+++ b/output/example/index.css
@@ -68,7 +68,6 @@ textarea#text_area::placeholder {
 textarea#text_area:focus {
   border: 0;
   outline: none;
-  color: #000;
 }
 
 textarea#text_area:focus ~ * #edit_area,
@@ -416,10 +415,6 @@ blockquote {
   }
 
   textarea#text_area {
-    color: #fff;
-  }
-
-  textarea#text_area:focus {
     color: #fff;
   }
 


### PR DESCRIPTION
Minor CSS style changes:

### Light Theme (E-ink Friendly):
Switched the focus indicator from blue background to a border.
Blue background appears as unclear gray on E-ink screens. Borders provide better contrast.

#### Before:

<img width="940" height="160" alt="image" src="https://github.com/user-attachments/assets/8a826a4b-7227-4af2-9924-dd673a218b42" />

<img width="935" height="171" alt="image" src="https://github.com/user-attachments/assets/fc8f6dfb-38c9-47ef-80ae-321460dc7d8c" />

#### After:

<img width="931" height="176" alt="Screenshot 2025-12-08 at 8 27 15 PM" src="https://github.com/user-attachments/assets/ca5f948e-acd8-4326-9604-0dfe367560bf" />

<img width="930" height="186" alt="Screenshot 2025-12-08 at 8 47 00 PM" src="https://github.com/user-attachments/assets/8e73849d-80a7-4b59-8f57-5b0896be6c3a" />


### Dark Theme:
Replaced any remaining white backgrounds with a dark color.
To ensure a fully consistent and homogeneous dark-mode experience.

#### Before:

<img width="935" height="157" alt="image" src="https://github.com/user-attachments/assets/21ad9296-adef-4421-8997-cd9beb6d02a8" />

<img width="932" height="178" alt="Screenshot 2025-12-08 at 8 46 20 PM" src="https://github.com/user-attachments/assets/e32f939e-f1f9-40f2-af5d-014af35dc6af" />

#### After:

<img width="928" height="165" alt="image" src="https://github.com/user-attachments/assets/0974be9a-657c-47c4-a45e-dabe2da10b5f" />

<img width="931" height="169" alt="Screenshot 2025-12-08 at 8 46 31 PM" src="https://github.com/user-attachments/assets/68d56927-2b8f-4cc0-b067-c2c2d8741c54" />
