### PR TITLE
Add Bopomofo font support and annotation features in ChromeOS extension

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ The input method supports rendering Bopomofo alongside Chinese characters using 
 
 - **Building**: Run `npm run build:mcp` to compile the MCP server to `output/mcp/index.js`.
 - **Running**: The server communicates via standard input/output (`stdio`). It can be started using `node output/mcp/index.js` or the wrapper `output/mcp/run.sh`.
-- **Tools**: It exposes LLM tools for text, Bopomofo, Pinyin, and Braille conversion (e.g., `convertBrailleToText`, `convertTextToBraille`, `convertTextToPinyin`).
+- **Tools**: It exposes LLM tools for text, Bopomofo, Pinyin, Bopomofo annotation font, and Braille conversion (e.g., `convertBrailleToText`, `convertTextToBraille`, `convertTextToPinyin`, `convertTextToBpmfAnnotatedText`).
 
 ### Testing Guidelines
 
@@ -233,6 +233,7 @@ AI agents may call a subagent to run `npm run test:coverage` to find code that i
 
 ## Additional Agent Notes
 
+- **DO NOT** modify any files under the `node_modules` directory.
 - Before merging, run `npm run test` and ensure Chrome OS build still compiles via `npm run build:chromeos`.
 - CI now runs `npm run build:mcp` across Node 18-24; run this build locally when changing MCP-related code to mirror CI.
 - New language model data must include a short note in `README.md` summarizing changes for translators.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,16 +12,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-        checks: write
-        pull-requests: write
-        contents: write
+      checks: write
+      pull-requests: write
+      contents: write
     strategy:
       matrix:
         node-version: [24.x, 23.x, 22.x, 21.x, 20.x, 19.x, 18.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -30,16 +30,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     permissions:
-        checks: write
-        pull-requests: write
-        contents: write
+      checks: write
+      pull-requests: write
+      contents: write
     strategy:
       matrix:
         node-version: [24.x, 23.x, 22.x, 21.x, 20.x, 19.x, 18.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -68,9 +68,9 @@ jobs:
       matrix:
         node-version: [24.x, 23.x, 22.x, 21.x, 20.x, 19.x, 18.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -82,9 +82,9 @@ jobs:
       matrix:
         node-version: [24.x, 23.x, 22.x, 21.x, 20.x, 19.x, 18.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -112,7 +112,7 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v4
   #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
+  #       uses: actions/setup-node@v6
   #       with:
   #         node-version: ${{ matrix.node-version }}
   #     - run: npm install
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
+          node-version: "20.x"
+          registry-url: "https://npm.pkg.github.com"
       - run: npm ci
       - run: npm test
       - run: npm publish

--- a/README.en.md
+++ b/README.en.md
@@ -121,6 +121,12 @@ After installing the McBopomofo MCP server, you can try the following prompts wi
 - Please convert the following Chinese characters into Bopomofo using the LLM's own AI capabilities, and then convert the Bopomofo into Taiwan Braille.
 - Please convert the following Braille to Chinese characters.
 - Please convert the following Braille to Bopomofo, and then use the LLM's own capabilities to convert the Bopomofo into Chinese characters.
+- Please convert the following Chinese characters to a Bopomofo annotated web page.
+- Please use the MCP tool to generate text with Bopomofo annotations.
+
+Note that the McBopomofo MCP supports generating the codes required for Bopomofo annotation fonts, but this feature requires additional font support. You can download the supported fonts from [here](https://github.com/ButTaiwan/bpmfvs/releases/tag/v1.500). If you want the AI to generate an HTML page with Bopomofo annotations, you can remind the AI in the prompt:
+
+> Please add the CSS stylesheet `https://oikasu1.github.io/fonts/twfonts.css` to the HTML, and then apply the `BpmfZihiSerif-Regular`, `BpmfZihiSans-Regular`, or `BpmfZihiKaiStd-Regular` font to the corresponding elements.
 
 You can also deploy it to other AI services that support MCP, such as Gemini CLI, according to your own needs.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ node index.js
 - 請將以下的國字，用 LLM 自己的 AI 能力轉換成注音後，然後將注音轉換成台灣點字。
 - 請將以下點字轉換成國字。
 - 請將以下點字轉換成注音後，再用 LLM 自己的能力，將注音轉換成國字。
+- 請將以下的國字轉換成帶有注音標記的網頁。
+- 請使用小麥注音 MCP 工具，將以下的國字轉換成注音字型內碼。
+
+小麥注音 MCP 支援產生注音字型（BPMF annotation font）所需要的內碼，但這個功能需要額外的字型支援。您可以從[這裡](https://github.com/ButTaiwan/bpmfvs/releases/tag/v1.500)下載支援的字型。如果您要請 AI 產生帶有注音的 HTML 網頁，您可以在 prompt 提醒 AI：
+
+> 請在 HTML 中加上 CSS stylesheet `https://oikasu1.github.io/fonts/twfonts.css`，然後在對應的元素套用 `BpmfZihiSerif-Regular`、`BpmfZihiSans-Regular` 或 `BpmfZihiKaiStd-Regular` 字體。
 
 您也可以按照自己的需求，部署在其他支援 MCP 的 AI 服務上，像是 Gemini CLI 等。
 

--- a/output/chromeos/_locales/en/messages.json
+++ b/output/chromeos/_locales/en/messages.json
@@ -180,25 +180,28 @@
     "message": "Using full-width punctuation"
   },
   "convert_text_to_bpmf_syllables": {
-    "message": "Convert text to Bopomofo syllables"
+    "message": "Convert to Bopomofo syllables"
   },
   "append_bpmf_syllables_to_text": {
     "message": "Append Bopomofo syllables to text"
   },
   "convert_text_to_html_ruby": {
-    "message": "Convert text to HTML Ruby"
+    "message": "Convert to HTML Ruby"
   },
   "append_taiwanese_braille": {
     "message": "Append Taiwanese Braille"
   },
   "convert_text_to_taiwanese_braille": {
-    "message": "Convert text to Taiwanese Braille"
+    "message": "Convert to Taiwanese Braille"
   },
   "convert_taiwanese_braille_to_text": {
     "message": "Convert Taiwanese Braille to text"
   },
   "convert_text_to_hanyu_pinyin": {
-    "message": "Convert text to Hanyu Pinyin"
+    "message": "Convert to Hanyu Pinyin"
+  },
+  "convert_text_to_bpmf_font_annotated_text": {
+    "message": "Convert to annotated text with Bopomofo Font support"
   },
   "menuHelp": {
     "message": "Help..."

--- a/output/chromeos/_locales/zh_TW/messages.json
+++ b/output/chromeos/_locales/zh_TW/messages.json
@@ -203,6 +203,9 @@
   "convert_text_to_hanyu_pinyin": {
     "message": "將國字轉換為漢語拼音"
   },
+  "convert_text_to_bpmf_font_annotated_text": {
+    "message": "轉換成加註字體的國字 (需要字體支援)"
+  },
   "menuHelp": {
     "message": "輔助說明"
   },

--- a/output/chromeos/content-script.js
+++ b/output/chromeos/content-script.js
@@ -1,64 +1,106 @@
-//Note: we added context menu items to convert text in the background worker,
-//and then the background worker sends the converted text to the content script.
-//The content script then replaces the selected text with the converted text.
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  function replaceSelectedText(replacementText, isHtml) {
-    let sel, range;
-    if (window.getSelection) {
-      sel = window.getSelection();
-      const activeElement = document.activeElement;
-      if (
-        activeElement.nodeName === "TEXTAREA" ||
-        (activeElement.nodeName === "INPUT" &&
-          activeElement.type.toLowerCase() === "text")
-      ) {
-        const val = activeElement.value;
-        const start = activeElement.selectionStart;
-        const end = activeElement.selectionEnd;
-        activeElement.value =
-          val.slice(0, start) + replacementText + val.slice(end);
-      } else {
-        if (sel.rangeCount) {
-          range = sel.getRangeAt(0);
-          range.deleteContents();
-          if (isHtml) {
-            const div = document.createElement("div");
-            div.innerHTML = replacementText;
-            range.insertNode(div);
-          } else {
-            const lines = replacementText.split("\n").reverse();
-            if (lines.length > 1) {
-              for (const line of lines) {
-                const p = document.createElement("p");
-                p.innerText = line;
-                range.insertNode(p);
-              }
-            } else {
-              range.insertNode(document.createTextNode(replacementText));
-            }
-          }
+(function () {
+  // Note: Add BPMT font.
+  const fontLink = document.createElement("link");
+  fontLink.rel = "stylesheet";
+  fontLink.href = "https://oikasu1.github.io/fonts/twfonts.css";
+  document.head.appendChild(fontLink);
+
+  let selectedText = "";
+
+  document.addEventListener("selectionchange", () => {
+    selectedText = window.getSelection().toString();
+  });
+
+  //Note: we added context menu items to convert text in the background worker,
+  //and then the background worker sends the converted text to the content script.
+  //The content script then replaces the selected text with the converted text.
+  chrome.runtime.onMessage.addListener(function (
+    request,
+    sender,
+    sendResponse
+  ) {
+    function replaceSelectedText(replacementText, isHtml, useBpmfFont) {
+      let sel, range;
+      if (window.getSelection) {
+        sel = window.getSelection();
+        const activeElement = document.activeElement;
+        if (
+          activeElement.nodeName === "TEXTAREA" ||
+          (activeElement.nodeName === "INPUT" &&
+            activeElement.type.toLowerCase() === "text")
+        ) {
+          const val = activeElement.value;
+          const start = activeElement.selectionStart;
+          const end = activeElement.selectionEnd;
+          activeElement.value =
+            val.slice(0, start) + replacementText + val.slice(end);
+          console.log("path 1");
         } else {
-          sel.deleteFromDocument();
+          if (sel.rangeCount) {
+            range = sel.getRangeAt(0);
+            range.deleteContents();
+            if (isHtml) {
+              const div = document.createElement("div");
+              div.innerHTML = replacementText;
+              if (useBpmfFont) {
+                div.style.fontFamily = "BpmfZihiSans-Regular";
+              }
+              range.insertNode(div);
+              console.log("path 2");
+            } else {
+              const lines = replacementText.split("\n").reverse();
+              console.log("lines", lines);
+              if (lines.length > 1) {
+                for (const line of lines) {
+                  if (line.length === 0) {
+                    continue;
+                  }
+                  let p = document.createElement("p");
+                  let node = document.createTextNode(line);
+                  p.appendChild(node);
+                  if (useBpmfFont) {
+                    p.style.fontFamily = "BpmfZihiSans-Regular";
+                  }
+                  range.insertNode(p);
+                }
+                console.log("path 3");
+              } else {
+                let node = document.createTextNode(replacementText);
+                if (useBpmfFont) {
+                  const p = document.createElement("p");
+                  p.appendChild(node);
+                  node = p;
+                  node.style.fontFamily = "BpmfZihiSans-Regular";
+                }
+                range.insertNode(node);
+              }
+            }
+          } else {
+            sel.deleteFromDocument();
+          }
         }
+      } else if (document.selection && document.selection.createRange) {
+        range = document.selection.createRange();
+        range.text = replacementText;
       }
-    } else if (document.selection && document.selection.createRange) {
-      range = document.selection.createRange();
-      range.text = replacementText;
     }
-  }
 
-  function beep() {
-    const snd = new Audio(
-      "data:audio/wav;base64,//uQRAAAAWMSLwUIYAAsYkXgoQwAEaYLWfkWgAI0wWs/ItAAAGDgYtAgAyN+QWaAAihwMWm4G8QQRDiMcCBcH3Cc+CDv/7xA4Tvh9Rz/y8QADBwMWgQAZG/ILNAARQ4GLTcDeIIIhxGOBAuD7hOfBB3/94gcJ3w+o5/5eIAIAAAVwWgQAVQ2ORaIQwEMAJiDg95G4nQL7mQVWI6GwRcfsZAcsKkJvxgxEjzFUgfHoSQ9Qq7KNwqHwuB13MA4a1q/DmBrHgPcmjiGoh//EwC5nGPEmS4RcfkVKOhJf+WOgoxJclFz3kgn//dBA+ya1GhurNn8zb//9NNutNuhz31f////9vt///z+IdAEAAAK4LQIAKobHItEIYCGAExBwe8jcToF9zIKrEdDYIuP2MgOWFSE34wYiR5iqQPj0JIeoVdlG4VD4XA67mAcNa1fhzA1jwHuTRxDUQ//iYBczjHiTJcIuPyKlHQkv/LHQUYkuSi57yQT//uggfZNajQ3Vmz+Zt//+mm3Wm3Q576v////+32///5/EOgAAADVghQAAAAA//uQZAUAB1WI0PZugAAAAAoQwAAAEk3nRd2qAAAAACiDgAAAAAAABCqEEQRLCgwpBGMlJkIz8jKhGvj4k6jzRnqasNKIeoh5gI7BJaC1A1AoNBjJgbyApVS4IDlZgDU5WUAxEKDNmmALHzZp0Fkz1FMTmGFl1FMEyodIavcCAUHDWrKAIA4aa2oCgILEBupZgHvAhEBcZ6joQBxS76AgccrFlczBvKLC0QI2cBoCFvfTDAo7eoOQInqDPBtvrDEZBNYN5xwNwxQRfw8ZQ5wQVLvO8OYU+mHvFLlDh05Mdg7BT6YrRPpCBznMB2r//xKJjyyOh+cImr2/4doscwD6neZjuZR4AgAABYAAAABy1xcdQtxYBYYZdifkUDgzzXaXn98Z0oi9ILU5mBjFANmRwlVJ3/6jYDAmxaiDG3/6xjQQCCKkRb/6kg/wW+kSJ5//rLobkLSiKmqP/0ikJuDaSaSf/6JiLYLEYnW/+kXg1WRVJL/9EmQ1YZIsv/6Qzwy5qk7/+tEU0nkls3/zIUMPKNX/6yZLf+kFgAfgGyLFAUwY//uQZAUABcd5UiNPVXAAAApAAAAAE0VZQKw9ISAAACgAAAAAVQIygIElVrFkBS+Jhi+EAuu+lKAkYUEIsmEAEoMeDmCETMvfSHTGkF5RWH7kz/ESHWPAq/kcCRhqBtMdokPdM7vil7RG98A2sc7zO6ZvTdM7pmOUAZTnJW+NXxqmd41dqJ6mLTXxrPpnV8avaIf5SvL7pndPvPpndJR9Kuu8fePvuiuhorgWjp7Mf/PRjxcFCPDkW31srioCExivv9lcwKEaHsf/7ow2Fl1T/9RkXgEhYElAoCLFtMArxwivDJJ+bR1HTKJdlEoTELCIqgEwVGSQ+hIm0NbK8WXcTEI0UPoa2NbG4y2K00JEWbZavJXkYaqo9CRHS55FcZTjKEk3NKoCYUnSQ0rWxrZbFKbKIhOKPZe1cJKzZSaQrIyULHDZmV5K4xySsDRKWOruanGtjLJXFEmwaIbDLX0hIPBUQPVFVkQkDoUNfSoDgQGKPekoxeGzA4DUvnn4bxzcZrtJyipKfPNy5w+9lnXwgqsiyHNeSVpemw4bWb9psYeq//uQZBoABQt4yMVxYAIAAAkQoAAAHvYpL5m6AAgAACXDAAAAD59jblTirQe9upFsmZbpMudy7Lz1X1DYsxOOSWpfPqNX2WqktK0DMvuGwlbNj44TleLPQ+Gsfb+GOWOKJoIrWb3cIMeeON6lz2umTqMXV8Mj30yWPpjoSa9ujK8SyeJP5y5mOW1D6hvLepeveEAEDo0mgCRClOEgANv3B9a6fikgUSu/DmAMATrGx7nng5p5iimPNZsfQLYB2sDLIkzRKZOHGAaUyDcpFBSLG9MCQALgAIgQs2YunOszLSAyQYPVC2YdGGeHD2dTdJk1pAHGAWDjnkcLKFymS3RQZTInzySoBwMG0QueC3gMsCEYxUqlrcxK6k1LQQcsmyYeQPdC2YfuGPASCBkcVMQQqpVJshui1tkXQJQV0OXGAZMXSOEEBRirXbVRQW7ugq7IM7rPWSZyDlM3IuNEkxzCOJ0ny2ThNkyRai1b6ev//3dzNGzNb//4uAvHT5sURcZCFcuKLhOFs8mLAAEAt4UWAAIABAAAAAB4qbHo0tIjVkUU//uQZAwABfSFz3ZqQAAAAAngwAAAE1HjMp2qAAAAACZDgAAAD5UkTE1UgZEUExqYynN1qZvqIOREEFmBcJQkwdxiFtw0qEOkGYfRDifBui9MQg4QAHAqWtAWHoCxu1Yf4VfWLPIM2mHDFsbQEVGwyqQoQcwnfHeIkNt9YnkiaS1oizycqJrx4KOQjahZxWbcZgztj2c49nKmkId44S71j0c8eV9yDK6uPRzx5X18eDvjvQ6yKo9ZSS6l//8elePK/Lf//IInrOF/FvDoADYAGBMGb7FtErm5MXMlmPAJQVgWta7Zx2go+8xJ0UiCb8LHHdftWyLJE0QIAIsI+UbXu67dZMjmgDGCGl1H+vpF4NSDckSIkk7Vd+sxEhBQMRU8j/12UIRhzSaUdQ+rQU5kGeFxm+hb1oh6pWWmv3uvmReDl0UnvtapVaIzo1jZbf/pD6ElLqSX+rUmOQNpJFa/r+sa4e/pBlAABoAAAAA3CUgShLdGIxsY7AUABPRrgCABdDuQ5GC7DqPQCgbbJUAoRSUj+NIEig0YfyWUho1VBBBA//uQZB4ABZx5zfMakeAAAAmwAAAAF5F3P0w9GtAAACfAAAAAwLhMDmAYWMgVEG1U0FIGCBgXBXAtfMH10000EEEEEECUBYln03TTTdNBDZopopYvrTTdNa325mImNg3TTPV9q3pmY0xoO6bv3r00y+IDGid/9aaaZTGMuj9mpu9Mpio1dXrr5HERTZSmqU36A3CumzN/9Robv/Xx4v9ijkSRSNLQhAWumap82WRSBUqXStV/YcS+XVLnSS+WLDroqArFkMEsAS+eWmrUzrO0oEmE40RlMZ5+ODIkAyKAGUwZ3mVKmcamcJnMW26MRPgUw6j+LkhyHGVGYjSUUKNpuJUQoOIAyDvEyG8S5yfK6dhZc0Tx1KI/gviKL6qvvFs1+bWtaz58uUNnryq6kt5RzOCkPWlVqVX2a/EEBUdU1KrXLf40GoiiFXK///qpoiDXrOgqDR38JB0bw7SoL+ZB9o1RCkQjQ2CBYZKd/+VJxZRRZlqSkKiws0WFxUyCwsKiMy7hUVFhIaCrNQsKkTIsLivwKKigsj8XYlwt/WKi2N4d//uQRCSAAjURNIHpMZBGYiaQPSYyAAABLAAAAAAAACWAAAAApUF/Mg+0aohSIRobBAsMlO//Kk4soosy1JSFRYWaLC4qZBYWFRGZdwqKiwkNBVmoWFSJkWFxX4FFRQWR+LsS4W/rFRb/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////VEFHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU291bmRib3kuZGUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMjAwNGh0dHA6Ly93d3cuc291bmRib3kuZGUAAAAAAAAAACU="
-    );
-    snd.play();
-  }
+    function beep() {
+      const snd = new Audio(
+        "data:audio/wav;base64,//uQRAAAAWMSLwUIYAAsYkXgoQwAEaYLWfkWgAI0wWs/ItAAAGDgYtAgAyN+QWaAAihwMWm4G8QQRDiMcCBcH3Cc+CDv/7xA4Tvh9Rz/y8QADBwMWgQAZG/ILNAARQ4GLTcDeIIIhxGOBAuD7hOfBB3/94gcJ3w+o5/5eIAIAAAVwWgQAVQ2ORaIQwEMAJiDg95G4nQL7mQVWI6GwRcfsZAcsKkJvxgxEjzFUgfHoSQ9Qq7KNwqHwuB13MA4a1q/DmBrHgPcmjiGoh//EwC5nGPEmS4RcfkVKOhJf+WOgoxJclFz3kgn//dBA+ya1GhurNn8zb//9NNutNuhz31f////9vt///z+IdAEAAAK4LQIAKobHItEIYCGAExBwe8jcToF9zIKrEdDYIuP2MgOWFSE34wYiR5iqQPj0JIeoVdlG4VD4XA67mAcNa1fhzA1jwHuTRxDUQ//iYBczjHiTJcIuPyKlHQkv/LHQUYkuSi57yQT//uggfZNajQ3Vmz+Zt//+mm3Wm3Q576v////+32///5/EOgAAADVghQAAAAA//uQZAUAB1WI0PZugAAAAAoQwAAAEk3nRd2qAAAAACiDgAAAAAAABCqEEQRLCgwpBGMlJkIz8jKhGvj4k6jzRnqasNKIeoh5gI7BJaC1A1AoNBjJgbyApVS4IDlZgDU5WUAxEKDNmmALHzZp0Fkz1FMTmGFl1FMEyodIavcCAUHDWrKAIA4aa2oCgILEBupZgHvAhEBcZ6joQBxS76AgccrFlczBvKLC0QI2cBoCFvfTDAo7eoOQInqDPBtvrDEZBNYN5xwNwxQRfw8ZQ5wQVLvO8OYU+mHvFLlDh05Mdg7BT6YrRPpCBznMB2r//xKJjyyOh+cImr2/4doscwD6neZjuZR4AgAABYAAAABy1xcdQtxYBYYZdifkUDgzzXaXn98Z0oi9ILU5mBjFANmRwlVJ3/6jYDAmxaiDG3/6xjQQCCKkRb/6kg/wW+kSJ5//rLobkLSiKmqP/0ikJuDaSaSf/6JiLYLEYnW/+kXg1WRVJL/9EmQ1YZIsv/6Qzwy5qk7/+tEU0nkls3/zIUMPKNX/6yZLf+kFgAfgGyLFAUwY//uQZAUABcd5UiNPVXAAAApAAAAAE0VZQKw9ISAAACgAAAAAVQIygIElVrFkBS+Jhi+EAuu+lKAkYUEIsmEAEoMeDmCETMvfSHTGkF5RWH7kz/ESHWPAq/kcCRhqBtMdokPdM7vil7RG98A2sc7zO6ZvTdM7pmOUAZTnJW+NXxqmd41dqJ6mLTXxrPpnV8avaIf5SvL7pndPvPpndJR9Kuu8fePvuiuhorgWjp7Mf/PRjxcFCPDkW31srioCExivv9lcwKEaHsf/7ow2Fl1T/9RkXgEhYElAoCLFtMArxwivDJJ+bR1HTKJdlEoTELCIqgEwVGSQ+hIm0NbK8WXcTEI0UPoa2NbG4y2K00JEWbZavJXkYaqo9CRHS55FcZTjKEk3NKoCYUnSQ0rWxrZbFKbKIhOKPZe1cJKzZSaQrIyULHDZmV5K4xySsDRKWOruanGtjLJXFEmwaIbDLX0hIPBUQPVFVkQkDoUNfSoDgQGKPekoxeGzA4DUvnn4bxzcZrtJyipKfPNy5w+9lnXwgqsiyHNeSVpemw4bWb9psYeq//uQZBoABQt4yMVxYAIAAAkQoAAAHvYpL5m6AAgAACXDAAAAD59jblTirQe9upFsmZbpMudy7Lz1X1DYsxOOSWpfPqNX2WqktK0DMvuGwlbNj44TleLPQ+Gsfb+GOWOKJoIrWb3cIMeeON6lz2umTqMXV8Mj30yWPpjoSa9ujK8SyeJP5y5mOW1D6hvLepeveEAEDo0mgCRClOEgANv3B9a6fikgUSu/DmAMATrGx7nng5p5iimPNZsfQLYB2sDLIkzRKZOHGAaUyDcpFBSLG9MCQALgAIgQs2YunOszLSAyQYPVC2YdGGeHD2dTdJk1pAHGAWDjnkcLKFymS3RQZTInzySoBwMG0QueC3gMsCEYxUqlrcxK6k1LQQcsmyYeQPdC2YfuGPASCBkcVMQQqpVJshui1tkXQJQV0OXGAZMXSOEEBRirXbVRQW7ugq7IM7rPWSZyDlM3IuNEkxzCOJ0ny2ThNkyRai1b6ev//3dzNGzNb//4uAvHT5sURcZCFcuKLhOFs8mLAAEAt4UWAAIABAAAAAB4qbHo0tIjVkUU//uQZAwABfSFz3ZqQAAAAAngwAAAE1HjMp2qAAAAACZDgAAAD5UkTE1UgZEUExqYynN1qZvqIOREEFmBcJQkwdxiFtw0qEOkGYfRDifBui9MQg4QAHAqWtAWHoCxu1Yf4VfWLPIM2mHDFsbQEVGwyqQoQcwnfHeIkNt9YnkiaS1oizycqJrx4KOQjahZxWbcZgztj2c49nKmkId44S71j0c8eV9yDK6uPRzx5X18eDvjvQ6yKo9ZSS6l//8elePK/Lf//IInrOF/FvDoADYAGBMGb7FtErm5MXMlmPAJQVgWta7Zx2go+8xJ0UiCb8LHHdftWyLJE0QIAIsI+UbXu67dZMjmgDGCGl1H+vpF4NSDckSIkk7Vd+sxEhBQMRU8j/12UIRhzSaUdQ+rQU5kGeFxm+hb1oh6pWWmv3uvmReDl0UnvtapVaIzo1jZbf/pD6ElLqSX+rUmOQNpJFa/r+sa4e/pBlAABoAAAAA3CUgShLdGIxsY7AUABPRrgCABdDuQ5GC7DqPQCgbbJUAoRSUj+NIEig0YfyWUho1VBBBA//uQZB4ABZx5zfMakeAAAAmwAAAAF5F3P0w9GtAAACfAAAAAwLhMDmAYWMgVEG1U0FIGCBgXBXAtfMH10000EEEEEECUBYln03TTTdNBDZopopYvrTTdNa325mImNg3TTPV9q3pmY0xoO6bv3r00y+IDGid/9aaaZTGMuj9mpu9Mpio1dXrr5HERTZSmqU36A3CumzN/9Robv/Xx4v9ijkSRSNLQhAWumap82WRSBUqXStV/YcS+XVLnSS+WLDroqArFkMEsAS+eWmrUzrO0oEmE40RlMZ5+ODIkAyKAGUwZ3mVKmcamcJnMW26MRPgUw6j+LkhyHGVGYjSUUKNpuJUQoOIAyDvEyG8S5yfK6dhZc0Tx1KI/gviKL6qvvFs1+bWtaz58uUNnryq6kt5RzOCkPWlVqVX2a/EEBUdU1KrXLf40GoiiFXK///qpoiDXrOgqDR38JB0bw7SoL+ZB9o1RCkQjQ2CBYZKd/+VJxZRRZlqSkKiws0WFxUyCwsKiMy7hUVFhIaCrNQsKkTIsLivwKKigsj8XYlwt/WKi2N4d//uQRCSAAjURNIHpMZBGYiaQPSYyAAABLAAAAAAAACWAAAAApUF/Mg+0aohSIRobBAsMlO//Kk4soosy1JSFRYWaLC4qZBYWFRGZdwqKiwkNBVmoWFSJkWFxX4FFRQWR+LsS4W/rFRb/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////VEFHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU291bmRib3kuZGUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMjAwNGh0dHA6Ly93d3cuc291bmRib3kuZGUAAAAAAAAAACU="
+      );
+      snd.play();
+    }
 
-  if (request.command === "beep") {
-    beep();
-  } else if (request.command === "replace_text") {
-    const text = request.text;
-    const isHtml = request.isHtml;
-    replaceSelectedText(text, isHtml);
-  }
-});
+    if (request.command === "beep") {
+      beep();
+    } else if (request.command === "get_selected_text") {
+      sendResponse({ text: selectedText });
+    } else if (request.command === "replace_text") {
+      const text = request.text;
+      const isHtml = request.isHtml;
+      const useBpmfFont = request.useBpmfFont;
+      replaceSelectedText(text, isHtml, useBpmfFont);
+    }
+  });
+})();

--- a/output/chromeos/content-script.js
+++ b/output/chromeos/content-script.js
@@ -34,7 +34,6 @@
           const end = activeElement.selectionEnd;
           activeElement.value =
             val.slice(0, start) + replacementText + val.slice(end);
-          console.log("path 1");
         } else {
           if (sel.rangeCount) {
             range = sel.getRangeAt(0);
@@ -46,10 +45,8 @@
                 div.style.fontFamily = "BpmfZihiSans-Regular";
               }
               range.insertNode(div);
-              console.log("path 2");
             } else {
               const lines = replacementText.split("\n").reverse();
-              console.log("lines", lines);
               if (lines.length > 1) {
                 for (const line of lines) {
                   if (line.length === 0) {
@@ -63,7 +60,6 @@
                   }
                   range.insertNode(p);
                 }
-                console.log("path 3");
               } else {
                 let node = document.createTextNode(replacementText);
                 if (useBpmfFont) {

--- a/src/McBopomofo/Service.test.ts
+++ b/src/McBopomofo/Service.test.ts
@@ -207,4 +207,20 @@ describe("Service", () => {
     const result = service.convertTextToRawReadings(input);
     expect(result).toBe("ㄒㄧㄠˇ-ㄇㄞˋ-ㄓㄨˋ-ㄧㄣ-ㄕㄨ-ㄖㄨˋ-ㄈㄚˇ");
   });
+
+  test("test convertTextToBpmfAnnotatedText", () => {
+    const service = new Service();
+    const input = "一二三";
+    const result = service.convertTextToBpmfAnnotatedText(input);
+    // 一 (ㄧ), 二 (ㄦˋ), 三 (ㄙㄢ)
+    // From WebBpmfvsVariants.ts:
+    // "一-ㄧ": "一"
+    // "二-ㄦˋ": "二"
+    // "三-ㄙㄢ": "三"
+    // So there should be no variation selectors here as they are default readings.
+    expect(result).toBe("一二三");
+
+    const result2 = service.convertTextToBpmfAnnotatedText("還錢");
+    expect(result2).toBe("還󠇡錢");
+  });
 });

--- a/src/McBopomofo/Service.test.ts
+++ b/src/McBopomofo/Service.test.ts
@@ -223,4 +223,13 @@ describe("Service", () => {
     const result2 = service.convertTextToBpmfAnnotatedText("還錢");
     expect(result2).toBe("還󠇡錢");
   });
+
+  test("test annotateSingleCharacter", () => {
+    const service = new Service();
+    const result = service.annotateSingleCharacter("一", "ㄧ");
+    expect(result).toBe("一");
+
+    const result2 = service.annotateSingleCharacter("還", "ㄏㄨㄢˊ");
+    expect(result2).toBe("還󠇡");
+  });
 });

--- a/src/McBopomofo/Service.ts
+++ b/src/McBopomofo/Service.ts
@@ -6,6 +6,9 @@ import { ReadingGrid } from "../Gramambular2";
 import { webData } from "./WebData";
 import { WebLanguageModel } from "./WebLanguageModel";
 import { BopomofoSyllable as MandarinBopomofoSyllable } from "../Mandarin";
+import { VariantAnnotator } from "./VariantAnnotator";
+import { webBpmfvsPua } from "./WebBpmfvsPua";
+import { webBpmfvsVariants } from "./WebBpmfvsVariants";
 
 const ChineseConvert = require("chinese_convert");
 
@@ -21,10 +24,12 @@ const ChineseConvert = require("chinese_convert");
 export class Service {
   private lm_: WebLanguageModel;
   private grid_: ReadingGrid;
+  private vs_: VariantAnnotator;
 
   constructor() {
     this.lm_ = new WebLanguageModel(webData);
     this.grid_ = new ReadingGrid(this.lm_);
+    this.vs_ = new VariantAnnotator(webBpmfvsPua, webBpmfvsVariants);
   }
 
   /**
@@ -250,6 +255,32 @@ export class Service {
       input,
       (reading: string, value: string) => {
         return reading;
+      },
+      (input: string) => {
+        return input;
+      }
+    );
+  }
+
+  /**
+   * Converts text to Bopomofo annotated text.
+   * @param input The text input
+   * @returns The annotated text output
+   * @example
+   * ``` typescript
+   * let service = new Service();
+   * let input = "小麥注音輸入法";
+   * let output = service.convertTextToBpmfAnnotatedText(input);
+   * ```
+   */
+  public convertTextToBpmfAnnotatedText(input: string): string {
+    return this.convertText(
+      input,
+      (reading: string, value: string) => {
+        let valueComponents = value.split("");
+        let readings = reading.split("-");
+        const result = this.vs_.annotate(valueComponents, readings);
+        return result.annotatedString;
       },
       (input: string) => {
         return input;

--- a/src/McBopomofo/Service.ts
+++ b/src/McBopomofo/Service.ts
@@ -378,4 +378,15 @@ export class Service {
       true
     );
   }
+
+  /**
+   * Annotates a single character with its Bopomofo reading.
+   *
+   * @param input - The character to be annotated.
+   * @param reading - The Bopomofo reading for the character.
+   * @returns The annotated string representation of the character.
+   */
+  public annotateSingleCharacter(input: string, reading: string): string {
+    return this.vs_.annotateSingleCharacter(input, reading).annotatedString;
+  }
 }

--- a/src/McBopomofo/Service.ts
+++ b/src/McBopomofo/Service.ts
@@ -13,13 +13,16 @@ import { webBpmfvsVariants } from "./WebBpmfvsVariants";
 const ChineseConvert = require("chinese_convert");
 
 /**
- * The text conversion service.
+ * The text conversion service used in the Chrome Extension and the MCP server.
  *
  * The service provides the following functions:
  *  - Convert Taiwanese Braille to text
  *  - Convert text to Bopomofo readings
+ *  - Convert text to Hanyu Pinyin
  *  - Convert text to HTML Ruby
  *  - Convert text to Taiwanese Braille
+ *  - Convert text to Bopomofo annotated text (for Bopomofo annotation fonts)
+ *  - Annotate a single character with its Bopomofo reading
  */
 export class Service {
   private lm_: WebLanguageModel;

--- a/src/chromeos_ime.ts
+++ b/src/chromeos_ime.ts
@@ -984,7 +984,6 @@ chrome.contextMenus.onClicked.addListener((event, tab) => {
     { command: "get_selected_text" },
     (response) => {
       if (response && response.text) {
-        // console.log("這才有換行：", response.text);
         handle(response.text, menuItemId as string, tabId as number);
       }
     }

--- a/src/chromeos_ime.ts
+++ b/src/chromeos_ime.ts
@@ -671,7 +671,7 @@ chrome.input?.ime.onBlur.addListener((context) => {
 //
 chrome.input?.ime.onReset.addListener((context) => {
   let maybeGoogleDocs = false;
-  if (chromeMcBopomofo.context != undefined) {
+  if (chromeMcBopomofo.context !== undefined) {
     maybeGoogleDocs =
       chromeMcBopomofo.context.type === "text" &&
       chromeMcBopomofo.context.autoCapitalize !== "characters" &&
@@ -876,6 +876,7 @@ chrome.contextMenus.onClicked.addListener((event, tab) => {
     }
     let converted = selectionText;
     let isHtml = false;
+    let useBpmfFont = false;
 
     if (menuItemId === "convert_text_to_bpmf_syllables") {
       const lines = selectionText.split("\n");
@@ -909,7 +910,6 @@ chrome.contextMenus.onClicked.addListener((event, tab) => {
         convertedLines.push(convertedLine);
       }
       converted = convertedLines.join("\n");
-
       isHtml = true;
     } else if (menuItemId === "append_taiwanese_braille") {
       const lines = selectionText.split("\n");
@@ -951,12 +951,25 @@ chrome.contextMenus.onClicked.addListener((event, tab) => {
         convertedLines.push(convertedLine);
       }
       converted = convertedLines.join("\n");
+    } else if (menuItemId === "convert_text_to_bpmf_font_annotated_text") {
+      useBpmfFont = true;
+      const lines = selectionText.split("\n");
+      const convertedLines = [];
+      for (const line of lines) {
+        let convertedLine = ChineseConvert.cn2tw(line);
+        convertedLine =
+          chromeMcBopomofo.service.convertTextToBpmfAnnotatedText(
+            convertedLine
+          );
+        convertedLines.push(convertedLine);
+      }
+      converted = convertedLines.join("\n");
     }
-
     chrome.tabs.sendMessage(tabId, {
       command: "replace_text",
       text: converted,
       isHtml: isHtml,
+      useBpmfFont: useBpmfFont,
     });
   }
 
@@ -966,11 +979,16 @@ chrome.contextMenus.onClicked.addListener((event, tab) => {
     return;
   }
 
-  const selected = event.selectionText;
-  if (selected === undefined) {
-    return;
-  }
-  handle(selected, menuItemId as string, tabId as number);
+  chrome.tabs.sendMessage(
+    tabId,
+    { command: "get_selected_text" },
+    (response) => {
+      if (response && response.text) {
+        // console.log("這才有換行：", response.text);
+        handle(response.text, menuItemId as string, tabId as number);
+      }
+    }
+  );
 });
 
 chrome.contextMenus.create({
@@ -1012,6 +1030,12 @@ chrome.contextMenus.create({
 chrome.contextMenus.create({
   id: "convert_text_to_hanyu_pinyin",
   title: chrome.i18n.getMessage("convert_text_to_hanyu_pinyin"),
+  contexts: ["selection", "editable"],
+});
+
+chrome.contextMenus.create({
+  id: "convert_text_to_bpmf_font_annotated_text",
+  title: chrome.i18n.getMessage("convert_text_to_bpmf_font_annotated_text"),
   contexts: ["selection", "editable"],
 });
 

--- a/src/chromeos_ime.ts
+++ b/src/chromeos_ime.ts
@@ -684,13 +684,13 @@ chrome.input?.ime.onReset.addListener((context) => {
   }
 
   let maybeTwitter = false;
-  if (chromeMcBopomofo.context != undefined) {
+  if (chromeMcBopomofo.context !== undefined) {
     maybeTwitter =
       chromeMcBopomofo.context.type === "text" &&
       chromeMcBopomofo.context.autoCapitalize === "sentences" &&
       chromeMcBopomofo.context.autoComplete === true &&
       chromeMcBopomofo.context.autoCorrect === true &&
-      chromeMcBopomofo.context.shouldDoLearning == true &&
+      chromeMcBopomofo.context.shouldDoLearning === true &&
       chromeMcBopomofo.context.spellCheck === true;
   }
   if (maybeTwitter) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -42,7 +42,7 @@ async function runServerTransport() {
     "convertTextToBraille",
     {
       description:
-        "將國字、數字或英文字母轉換為台灣點字 (Convert Chinese text to Taiwanese Braille) ",
+        "將國字、數字或英文字母轉換為台灣點字 (Convert Chinese text to Taiwanese Braille) 。請注意，這個工具會先將國字轉換成注音，再用這個工具，將注音轉換成點字，轉換過程不見得精確，如果 LLM 自己有更好的轉換能力，可以考慮使用 LLM 的能力，然後呼叫 convertBpmfToBraille 工具。 (If LLM needs precise braille conversion, LLM can first convert Chinese characters to bopomofo, then use this tool to convert bopomofo to braille)",
       inputSchema: {
         text: z.string().describe("中英文混合的字串，像是 'Hi 你好'"),
       },
@@ -112,7 +112,7 @@ async function runServerTransport() {
     "convertTextToBpmfReadings",
     {
       description:
-        "將國字轉換成注音 (Convert Chinese text to Bopomofo syllable).",
+        "將國字轉換成注音 (Convert Chinese text to Bopomofo syllable)。請注意，這個工具將國字轉換成注音的流程，是使用小麥詞庫加上簡單的分析，因此可能有錯字，如果 LLM 自己有更好的轉換能力，可以考慮使用 LLM 的能力。(Please note that this tool converts Chinese characters to Bopomofo using the McBopomofo dictionary together with a simple analysis process. As a result, conversion errors may occur. If the LLM itself has a better conversion capability, it may consider using its own ability instead.)",
       inputSchema: {
         text: z
           .string()
@@ -144,6 +144,53 @@ async function runServerTransport() {
     },
     async ({ text }) => {
       const result = service.convertTextToPinyin(text);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      };
+    }
+  );
+  server.registerTool(
+    "convertTextToBpmfAnnotatedText",
+    {
+      description:
+        "將國字轉換成支援注音字體的文字 (Convert Chinese text to Bopomofo annotated text)。請注意，這個工具將國字轉換成注音的流程，是使用小麥詞庫加上簡單的分析，因此可能有錯字。(Please note that this tool converts Chinese characters to Bopomofo using the McBopomofo dictionary together with a simple analysis process. As a result, conversion errors may occur.) 這個功能需要額外字體支援，可以提是用戶，如果要產生 HTML 結果，要先在 HTML 中加上一個 CSS stylesheet https://oikasu1.github.io/fonts/twfonts.css ，然後套用 BpmfZihiSerif-Regular、BpmfZihiSans-Regular 或 BpmfZihiKaiStd-Regular 等字體 (If you want to generate HTML results, you can first add a CSS stylesheet https://oikasu1.github.io/fonts/twfonts.css and then apply the fonts like BpmfZihiSerif-Regular, BpmfZihiSans-Regular, or BpmfZihiKaiStd-Regular.)",
+      inputSchema: {
+        text: z
+          .string()
+          .describe("包含國字 、數字或英文的字串 (Text content), 例如: 你好"),
+      },
+      annotations: {},
+    },
+    async ({ text }) => {
+      const result = service.convertTextToBpmfAnnotatedText(text);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      };
+    }
+  );
+  server.registerTool(
+    "annotateSingleCharacter",
+    {
+      description:
+        "將單一國字注音，轉換成標記字體的字串 (Convert a single Chinese character to a string with annotations)。如果 LLM 知道一個字的注音，就可以使用這個工具，將注音轉換成標記字體的字串。(If LLM knows a character's reading, it can use this tool to convert the reading to a string with annotations)。這個功能需要額外字體支援，可以提是用戶，如果要產生 HTML 結果，要先在 HTML 中加上一個 CSS stylesheet https://oikasu1.github.io/fonts/twfonts.css ，然後套用 BpmfZihiSerif-Regular、BpmfZihiSans-Regular 或 BpmfZihiKaiStd-Regular 等字體 (If you want to generate HTML results, you can first add a CSS stylesheet https://oikasu1.github.io/fonts/twfonts.css and then apply the fonts like BpmfZihiSerif-Regular, BpmfZihiSans-Regular, or BpmfZihiKaiStd-Regular.)",
+      inputSchema: {
+        text: z.string().describe("國字, 例如: 你"),
+        reading: z.string().describe("注音, 例如: ㄋㄧˇ"),
+      },
+      annotations: {},
+    },
+    async ({ text, reading }) => {
+      const result = service.annotateSingleCharacter(text, reading);
       return {
         content: [
           {


### PR DESCRIPTION
This pull request adds support for Bopomofo annotation fonts throughout the McBopomofo project, enabling conversion of Chinese text to annotated text compatible with special Bopomofo fonts. The changes include new features in the MCP server and Chrome extension, user documentation updates, new context menu actions, and internationalization support for the new functionality.

**Feature: Bopomofo Annotation Font Support**

* Added `convertTextToBpmfAnnotatedText` and `annotateSingleCharacter` methods to the `Service` class, enabling conversion of Chinese text and single characters to annotated text for Bopomofo font support. [[1]](diffhunk://#diff-d9e4707d150e8cb96832faedcb4cc32b9321e8dd87c298ddb235d2f97c0c5d84R268-R293) [[2]](diffhunk://#diff-d9e4707d150e8cb96832faedcb4cc32b9321e8dd87c298ddb235d2f97c0c5d84R384-R394)
* Registered new LLM tools in the MCP server for Bopomofo annotation font conversion and single character annotation, with detailed descriptions and input schemas.

**Chrome Extension Integration**

* Added a new context menu item (`convert_text_to_bpmf_font_annotated_text`) in the Chrome extension for converting selected text to Bopomofo annotated text, including support for applying the correct font in the content script and injecting the necessary CSS stylesheet. [[1]](diffhunk://#diff-2c6a88e0c22aa09079a0e9dfeb6597886f2c7d4eca7af5fc9c3ccb2cb22472cbR879) [[2]](diffhunk://#diff-2c6a88e0c22aa09079a0e9dfeb6597886f2c7d4eca7af5fc9c3ccb2cb22472cbR954-R972) [[3]](diffhunk://#diff-2c6a88e0c22aa09079a0e9dfeb6597886f2c7d4eca7af5fc9c3ccb2cb22472cbR1036-R1041) [[4]](diffhunk://#diff-76e30729a4bffbdef25283dd151ebc34cb30d80abc433526078c4fa45004e7f6R1-R22) [[5]](diffhunk://#diff-76e30729a4bffbdef25283dd151ebc34cb30d80abc433526078c4fa45004e7f6R37-R75) [[6]](diffhunk://#diff-76e30729a4bffbdef25283dd151ebc34cb30d80abc433526078c4fa45004e7f6R97-R106)

**Internationalization**

* Added English and Traditional Chinese i18n strings for the new Bopomofo annotation font feature in `messages.json`. [[1]](diffhunk://#diff-57f953d0e634a7b561000142bbd7249e7c991283f65c699c0b71b2f6d54413f3L183-R204) [[2]](diffhunk://#diff-6cd52a6c57c18f322fd783a829db55176d27b6cbad61227ac8bd3a1f46e8ddbfR206-R208)

**Documentation Updates**

* Updated `README.md`, `README.en.md`, and `.github/copilot-instructions.md` with usage instructions, prompts, and notes about the new annotation font feature and required font downloads. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L106-R106) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R124-R129) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R134)

**Testing**

* Added unit tests for `convertTextToBpmfAnnotatedText` and `annotateSingleCharacter` in `Service.test.ts` to ensure correctness of the new annotation logic.

These changes provide comprehensive support for Bopomofo annotation fonts, making it easier for users to generate and display annotated Chinese text in compatible environments.