### PR TITLE
Add Viterbi Graph Visualizer

### DIFF
--- a/output/example/index.css
+++ b/output/example/index.css
@@ -848,3 +848,56 @@ button {
 button:hover {
   border-width: 2px !important;
 } */
+
+#graph_walk_result {
+  display: none;
+  margin-bottom: 8px;
+}
+
+#graph_walk_result > div {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+#graph_result_text {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 1.1em;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  cursor: default;
+}
+
+#graph_result_score {
+  width: 100px;
+  text-align: center;
+  padding: 6px 10px;
+  font-size: 1.1em;
+  font-family: monospace;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+  cursor: default;
+}
+
+#mermaid_graph_container {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-3);
+  overflow: auto;
+  min-height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#mermaid_graph_output {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}

--- a/output/example/index.html
+++ b/output/example/index.html
@@ -82,6 +82,8 @@
       <a href="#feature_add_bpmf" title="將國字加上注音">國字加注音</a>
       <a href="#feature_convert_hanyupnyin" title="將國字轉換成漢語拼音">國字轉拼音</a>
       <span>｜</span>
+      <a href="#feature_graph" title="繪製選字路徑圖">選字路徑圖</a>
+      <span>｜</span>
       <a href="https://openvanilla.github.io/McBopomofoWeb/docs/" target="_top" title="API Reference">API Reference</a>
     </div>
 
@@ -750,6 +752,54 @@
       </div>
     </section>
 
+    <section id="feature_graph" class="feature" style="display: none;">
+      <div class="left">
+        <textarea placeholder="輸入注音符號，例如：ㄒㄧㄠˇ ㄇㄞˋ ㄓㄨˋ ㄧㄣ" id="feature_graph_text_area" rows="4" cols="50" title="輸入區"
+          autocapitalize="off"></textarea>
+        <div id="graph_ime_warning" style="
+              display: none;
+              background-color: #ffeb3b;
+              color: #d84315;
+              padding: 8px;
+              margin-top: 8px;
+              margin-bottom: 8px;
+              border-radius: 4px;
+              font-weight: bold;
+            ">
+          ⚠️
+          偵測到系統輸入法介入，請暫時關閉您的系統輸入法，直接使用英數鍵盤打字。
+        </div>
+        <p>
+          <button type="button" onclick="example.service.drawGraph()">
+            產生選字路徑圖
+          </button>
+        </p>
+        <div id="graph_walk_result">
+          <div>
+            <input type="text" id="graph_result_text" disabled
+              title="選字演算法結果" />
+            <input type="text" id="graph_result_score" disabled
+              title="加總對數機率 (log-probability)" />
+          </div>
+        </div>
+        <div id="mermaid_graph_container">
+          <pre class="mermaid" id="mermaid_graph_output"></pre>
+        </div>
+      </div>
+      <div class="right">
+        <h2>選字路徑圖</h2>
+        <p>請在輸入框中輸入注音符號 (以空格或連字號分隔) 或鍵盤對應鍵。</p>
+        <p>
+          此功能可讓您檢視小麥注音的選字演算法原理，並繪製出狀態轉移圖：
+        </p>
+        <ul>
+          <li>每個節點代表音節之間的分隔位置 (例如 5 個音節有 V0 ~ V5)</li>
+          <li>有向邊代表從某個位置開始、跨越特定長度的候選詞彙與其權重 (對數機率)</li>
+          <li>著色路徑代表最終被演算法選中的最佳結果</li>
+        </ul>
+      </div>
+    </section>
+
     <footer class="credit">
       Copyright (c) 2022 and onwards The McBopomofo Authors. This code is
       released under the MIT license.版本：2.0.4.
@@ -758,6 +808,7 @@
   </main>
 </body>
 
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/simple-keyboard/3.8.84/index.js"
   integrity="sha512-7yqZlyJktAkpzg+ARxg3IwkgZ4hPzP7MBE5XK1kA5UASQUiI8v9uVJTGyC82k3/SVcyi/uInOtsHGhQrG2fqQQ=="
   crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/output/example/index.js
+++ b/output/example/index.js
@@ -617,6 +617,54 @@ if (typeof document !== "undefined") {
         }
       };
 
+      that.drawGraph = async () => {
+        const text = getTrimmedValue("feature_graph_text_area");
+        const container = $("mermaid_graph_output");
+        const resultRow = $("graph_walk_result");
+        const resultText = $("graph_result_text");
+        const resultScore = $("graph_result_score");
+
+        if (text.length === 0) {
+          container.innerHTML = "graph LR\n  empty((請輸入注音符號))";
+          container.removeAttribute("data-processed");
+          if (resultRow) resultRow.style.display = "none";
+          if (typeof mermaid !== "undefined") {
+            try {
+              await mermaid.run({
+                nodes: [container]
+              });
+            } catch (err) {
+              console.error(err);
+            }
+          }
+          return;
+        }
+
+        const graphString = that.service.generateMermaidGraph(text);
+        container.innerHTML = graphString;
+        container.removeAttribute("data-processed");
+
+        const walkResult = that.service.getWalkResult(text);
+        if (resultRow && resultText && resultScore) {
+          resultText.value = walkResult.text;
+          resultScore.value = `${walkResult.score.toFixed(2)}`;
+          resultRow.style.display = "block";
+        }
+
+        if (typeof mermaid !== "undefined") {
+          try {
+            await mermaid.run({
+              nodes: [container]
+            });
+          } catch (err) {
+            console.error("Mermaid error:", err);
+            container.innerHTML = `<pre style="color:red;">${err.message}</pre>`;
+          }
+        } else {
+          container.innerHTML = `<pre>${graphString}</pre>`;
+        }
+      };
+
       return that;
     })();
 
@@ -1301,6 +1349,7 @@ if (typeof document !== "undefined") {
           "國字轉拼音",
         ],
         feature_generate_phrases: ["phrase_generate_input", "詞庫產生工具"],
+        feature_graph: ["feature_graph_text_area", "選字路徑圖"],
       };
 
       function toggle_feature(id, options = {}) {
@@ -1333,6 +1382,9 @@ if (typeof document !== "undefined") {
 
       window.addEventListener("hashchange", () => {
         onHashChange();
+        if (window.location.hash === "#feature_graph") {
+          service.drawGraph();
+        }
       });
       document.addEventListener("DOMContentLoaded", (event) => {
         const dropZone = $("vcard_drop_zone");
@@ -1375,11 +1427,231 @@ if (typeof document !== "undefined") {
           fileInput.value = "";
         });
 
+        // Bopomofo direct input helper for feature_graph_text_area
+        (() => {
+          let graphReadingBuffer = null;
+          let composingStart = null;
+          let lastValue = "";
+          // Snapshot of text that came after selectionEnd when composition began.
+          // Kept separate from lastValue so a selection range is replaced, not preserved.
+          let lastAfter = "";
+
+          function getActiveLayout() {
+            const { BopomofoKeyboardLayout } = window.mcbopomofo;
+            const name = settingsManager.settings.layout || "Standard";
+            switch (name) {
+              case "Standard":
+                return BopomofoKeyboardLayout.StandardLayout;
+              case "ETen":
+                return BopomofoKeyboardLayout.ETenLayout;
+              case "Hsu":
+                return BopomofoKeyboardLayout.HsuLayout;
+              case "ETen26":
+                return BopomofoKeyboardLayout.ETen26Layout;
+              case "HanyuPinyin":
+                return BopomofoKeyboardLayout.HanyuPinyinLayout;
+              case "IBM":
+                return BopomofoKeyboardLayout.IBMLayout;
+              default:
+                return BopomofoKeyboardLayout.StandardLayout;
+            }
+          }
+
+          function getGraphReadingBuffer() {
+            const { BopomofoReadingBuffer } = window.mcbopomofo;
+            const layout = getActiveLayout();
+            if (!graphReadingBuffer || graphReadingBuffer.keyboardLayout !== layout) {
+              graphReadingBuffer = new BopomofoReadingBuffer(layout);
+            }
+            return graphReadingBuffer;
+          }
+
+          const textarea = $("feature_graph_text_area");
+          let isGraphComposing = false;
+
+          textarea.addEventListener("compositionstart", (event) => {
+            isGraphComposing = true;
+            const warning = $("graph_ime_warning");
+            if (warning) {
+              warning.style.display = "block";
+            }
+          });
+
+          textarea.addEventListener("compositionend", (event) => {
+            isGraphComposing = false;
+            const warning = $("graph_ime_warning");
+            if (warning) {
+              warning.style.display = "none";
+            }
+          });
+
+          textarea.addEventListener("focus", () => {
+            const buffer = getGraphReadingBuffer();
+            buffer.clear();
+            composingStart = null;
+            lastAfter = "";
+          });
+
+          textarea.addEventListener("blur", () => {
+            const buffer = getGraphReadingBuffer();
+            if (!buffer.isEmpty) {
+              commitSyllable(buffer.composedString + " ", false);
+            }
+            composingStart = null;
+            lastAfter = "";
+          });
+
+          textarea.addEventListener("keydown", (event) => {
+            if (isGraphComposing || event.isComposing || event.keyCode === 229) {
+              return;
+            }
+
+            const buffer = getGraphReadingBuffer();
+
+            // Standard control keys (Ctrl+C, Cmd+A, etc.)
+            if (event.metaKey || event.ctrlKey || event.altKey) {
+              return;
+            }
+
+            const key = event.key;
+
+            if (key === "Backspace") {
+              if (!buffer.isEmpty) {
+                event.preventDefault();
+                buffer.backspace();
+                updateTextarea();
+                return;
+              } else {
+                composingStart = null;
+                lastAfter = "";
+                return;
+              }
+            }
+
+            if (key === " ") {
+              if (!buffer.isEmpty) {
+                event.preventDefault();
+                commitSyllable(buffer.composedString + " ");
+                return;
+              } else {
+                composingStart = null;
+                lastAfter = "";
+                return;
+              }
+            }
+
+            const lowerKey = key.toLowerCase();
+            if (buffer.isValidKey(lowerKey)) {
+              event.preventDefault();
+
+              const combined = buffer.combineKey(lowerKey);
+              if (combined) {
+                if (buffer.hasToneMarker) {
+                  commitSyllable(buffer.composedString + " ");
+                } else {
+                  updateTextarea();
+                }
+              } else {
+                if (!buffer.isEmpty) {
+                  commitSyllable(buffer.composedString + " ", false);
+                }
+                buffer.combineKey(lowerKey);
+                if (buffer.hasToneMarker) {
+                  commitSyllable(buffer.composedString + " ");
+                } else {
+                  updateTextarea();
+                }
+              }
+              return;
+            }
+
+            if (!buffer.isEmpty) {
+              commitSyllable(buffer.composedString + " ", false);
+            }
+            composingStart = null;
+            lastAfter = "";
+          });
+
+          function updateTextarea() {
+            const buffer = getGraphReadingBuffer();
+            const val = textarea.value;
+
+            if (composingStart === null) {
+              // Snapshot the composition anchor and the text that lies beyond
+              // selectionEnd. This correctly handles three cases:
+              //   1. Cursor at a point (selectionStart === selectionEnd) — text
+              //      after cursor is preserved.
+              //   2. A selection range — the selected text is replaced.
+              //   3. Cursor in the middle — nothing to the right is eaten.
+              composingStart = textarea.selectionStart;
+              lastValue = val;
+              lastAfter = val.substring(textarea.selectionEnd);
+            }
+
+            const before = lastValue.substring(0, composingStart);
+            const composing = buffer.composedString;
+
+            textarea.value = before + composing + lastAfter;
+            const newCursor = composingStart + composing.length;
+            textarea.setSelectionRange(newCursor, newCursor);
+          }
+
+          function commitSyllable(composedText, resetComposing = true) {
+            const buffer = getGraphReadingBuffer();
+            const val = textarea.value;
+
+            if (composingStart === null) {
+              // Same snapshot logic as updateTextarea.
+              composingStart = textarea.selectionStart;
+              lastValue = val;
+              lastAfter = val.substring(textarea.selectionEnd);
+            }
+
+            const before = lastValue.substring(0, composingStart);
+
+            textarea.value = before + composedText + lastAfter;
+            const newCursor = composingStart + composedText.length;
+            textarea.setSelectionRange(newCursor, newCursor);
+
+            buffer.clear();
+            if (resetComposing) {
+              composingStart = null;
+              lastAfter = "";
+            } else {
+              // Advance the anchor; lastAfter stays the same because the text
+              // to the right of the original selection hasn't changed.
+              composingStart = newCursor;
+              lastValue = textarea.value;
+            }
+          }
+        })();
+
         if (window.location.hash.length === 0) {
           window.history.replaceState(null, "", "#feature_input");
         }
+        function initMermaid() {
+          if (typeof mermaid === "undefined") return;
+          const isDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: isDark ? "dark" : "default"
+          });
+        }
+        initMermaid();
+        if (window.matchMedia) {
+          window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+            initMermaid();
+            // Redraw only when the graph tab is visible so we don't waste work.
+            if (window.location.hash === "#feature_graph") {
+              service.drawGraph();
+            }
+          });
+        }
         syntaxHighlightManager.init();
         onHashChange({ focus: false });
+        if (window.location.hash === "#feature_graph") {
+          service.drawGraph();
+        }
         window.requestAnimationFrame(() => {
           syntaxHighlightManager.refreshAll();
           resetInitialScrollPosition();

--- a/src/Gramambular2/ReadingGrid.ts
+++ b/src/Gramambular2/ReadingGrid.ts
@@ -90,6 +90,13 @@ export class ReadingGrid {
   }
 
   /**
+   * The spans in the grid.
+   */
+  get spans(): Span[] {
+    return this.spans_;
+  }
+
+  /**
    * Inserts a reading at the current cursor position.
    * @param reading The reading to insert.
    * @returns True if the reading was inserted, false otherwise.

--- a/src/McBopomofo/Service.test.ts
+++ b/src/McBopomofo/Service.test.ts
@@ -328,4 +328,45 @@ describe("Service", () => {
     const result2 = service.annotateSingleCharacter("還", "ㄏㄨㄢˊ");
     expect(result2).toBe("還󠇡");
   });
+
+  test("test generateMermaidGraph with Bopomofo input", () => {
+    const service = new Service();
+    const result = service.generateMermaidGraph("ㄕㄜˋ ㄐㄧˋ ㄔㄥˊ ㄕˋ ㄇㄚˇ");
+    expect(result).toContain("graph LR");
+    expect(result).toContain("V0");
+    expect(result).toContain("V5");
+    expect(result).toContain("classDef selected");
+    expect(result).toContain("linkStyle");
+  });
+
+  test("test generateMermaidGraph with layout keys input", () => {
+    const service = new Service();
+    const result = service.generateMermaidGraph("gk4 ru4 t/6 g4 a83");
+    expect(result).toContain("graph LR");
+    expect(result).toContain("V0");
+    expect(result).toContain("V5");
+    expect(result).toContain("classDef selected");
+    expect(result).toContain("linkStyle");
+  });
+
+  test("getWalkResult returns non-empty text for valid Bopomofo input", () => {
+    const service = new Service();
+    const result = service.getWalkResult("ㄕㄜˋ ㄐㄧˋ ㄔㄥˊ ㄕˋ ㄇㄚˇ");
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(0); // log-probability is always negative
+  });
+
+  test("getWalkResult text matches expected selection for unambiguous input", () => {
+    const service = new Service();
+    const result = service.getWalkResult("ㄒㄧㄠˇ ㄇㄞˋ ㄓㄨˋ ㄧㄣ");
+    expect(result.text).toBe("小麥注音");
+    expect(result.score).toBeLessThan(0);
+  });
+
+  test("getWalkResult returns empty text for empty input", () => {
+    const service = new Service();
+    const result = service.getWalkResult("");
+    expect(result.text).toBe("");
+    expect(result.score).toBe(0);
+  });
 });

--- a/src/McBopomofo/Service.ts
+++ b/src/McBopomofo/Service.ts
@@ -4,7 +4,11 @@ import {
   BrailleType,
 } from "../BopomofoBraille";
 import { ReadingGrid } from "../Gramambular2";
-import { BopomofoSyllable as MandarinBopomofoSyllable } from "../Mandarin";
+import {
+  BopomofoCharacterMap,
+  BopomofoKeyboardLayout,
+  BopomofoSyllable as MandarinBopomofoSyllable,
+} from "../Mandarin";
 import { VariantAnnotator } from "./VariantAnnotator";
 import { webBpmfvsPua } from "./WebBpmfvsPua";
 import { webBpmfvsVariants } from "./WebBpmfvsVariants";
@@ -476,5 +480,159 @@ export class Service {
    */
   public annotateSingleCharacter(input: string, reading: string): string {
     return this.vs_.annotateSingleCharacter(input, reading).annotatedString;
+  }
+
+  /**
+   * Parses `input` into Bopomofo syllables, builds a temporary ReadingGrid,
+   * and returns the grid together with the Viterbi walk result.
+   * Shared by `generateMermaidGraph` and `getWalkResult`.
+   */
+  private buildAndWalk(
+    input: string
+  ): { walkedNodes: ReturnType<ReadingGrid["walk"]>["nodes"]; tempGrid: ReadingGrid } | null {
+    const tokens = input.trim().split(/[\s-]+/).filter((t) => t.length > 0);
+    const layout = BopomofoKeyboardLayout.StandardLayout;
+    const syllables: string[] = [];
+
+    for (const token of tokens) {
+      let isBpmf = false;
+      for (let i = 0; i < token.length; i++) {
+        if (BopomofoCharacterMap.sharedInstance.characterToComponent.has(token.charAt(i))) {
+          isBpmf = true;
+          break;
+        }
+      }
+      if (isBpmf) {
+        const syllable = MandarinBopomofoSyllable.FromComposedString(token);
+        syllables.push(!syllable.isEmpty ? syllable.composedString : token);
+      } else {
+        const syllable = layout.syllableFromKeySequence(token);
+        syllables.push(!syllable.isEmpty ? syllable.composedString : token);
+      }
+    }
+
+    if (syllables.length === 0) return null;
+
+    const tempGrid = new ReadingGrid(this.lm_);
+    for (const syllable of syllables) {
+      tempGrid.insertReading(syllable);
+    }
+
+    const walkResult = tempGrid.walk();
+    return { walkedNodes: walkResult.nodes, tempGrid };
+  }
+
+  /**
+   * Returns the Viterbi-selected text and its total log-probability score
+   * for the given Bopomofo (or keyboard-sequence) input.
+   */
+  public getWalkResult(input: string): { text: string; score: number } {
+    const built = this.buildAndWalk(input);
+    if (!built) return { text: "", score: 0 };
+    const text = built.walkedNodes.map((n) => n.value).join("");
+    const score = built.walkedNodes.reduce((acc, n) => acc + n.score, 0);
+    return { text, score };
+  }
+
+  /**
+   * Generates a Mermaid graph representing candidate selections.
+   */
+  public generateMermaidGraph(input: string): string {
+    const built = this.buildAndWalk(input);
+    if (!built) return "graph LR\n  empty((Empty))";
+    const { walkedNodes, tempGrid } = built;
+
+    const walkedSegments: { start: number; end: number; node: any }[] = [];
+    let currentIdx = 0;
+    for (const walkedNode of walkedNodes) {
+      walkedSegments.push({
+        start: currentIdx,
+        end: currentIdx + walkedNode.spanningLength,
+        node: walkedNode,
+      });
+      currentIdx += walkedNode.spanningLength;
+    }
+
+    let mermaid = "graph LR\n";
+    for (let i = 0; i <= tempGrid.length; i++) {
+      mermaid += `  V${i}((V${i}))\n`;
+    }
+
+    interface Edge {
+      from: number;
+      to: number;
+      label: string;
+      isWalked: boolean;
+    }
+    const edges: Edge[] = [];
+
+    for (let i = 0; i < tempGrid.length; i++) {
+      const span = tempGrid.spans[i];
+      for (let len = 1; len <= span.maxLength; len++) {
+        const node = span.nodeOf(len);
+        if (!node) continue;
+
+        const isWalked = walkedSegments.some(
+          (seg) => seg.start === i && seg.end === i + len && seg.node === node
+        );
+
+        const value = node.value;
+        const score = node.score;
+        const label = `${value} ${score.toFixed(2)}`;
+
+        edges.push({
+          from: i,
+          to: i + len,
+          label,
+          isWalked,
+        });
+      }
+    }
+
+    edges.forEach((edge) => {
+      mermaid += `  V${edge.from} -->|"${edge.label}"| V${edge.to}\n`;
+    });
+
+    mermaid += "\n  classDef selected stroke:#e7000b,stroke-width:3px;\n";
+
+    const selectedVertices = new Set<number>([0]);
+    let accum = 0;
+    for (const walkedNode of walkedNodes) {
+      accum += walkedNode.spanningLength;
+      selectedVertices.add(accum);
+    }
+
+    const selectedList: string[] = [];
+    const stateList: string[] = [];
+    for (let i = 0; i <= tempGrid.length; i++) {
+      if (selectedVertices.has(i)) {
+        selectedList.push(`V${i}`);
+      } else {
+        stateList.push(`V${i}`);
+      }
+    }
+
+    if (selectedList.length > 0) {
+      mermaid += `  class ${selectedList.join(",")} selected;\n`;
+    }
+    if (stateList.length > 0) {
+      mermaid += `  class ${stateList.join(",")} state;\n`;
+    }
+
+    mermaid += "\n";
+    edges.forEach((edge, idx) => {
+      mermaid += `  %% Link ${idx}: V${edge.from}->V${edge.to}\n`;
+    });
+
+    const walkedLinkIndices = edges
+      .map((edge, idx) => (edge.isWalked ? idx : -1))
+      .filter((idx) => idx !== -1);
+
+    if (walkedLinkIndices.length > 0) {
+      mermaid += `\n  %% Highlight Link ${walkedLinkIndices.join(" & ")}\n`;
+      mermaid += `  linkStyle ${walkedLinkIndices.join(",")} stroke:#e7000b,stroke-width:3px,fill:none;\n`;
+    }
+    console.log(mermaid);
+    return mermaid;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@
 export { InputController } from "./McBopomofo/InputController";
 /** Conversion service for text, Bopomofo, pinyin, ruby, and braille workflows. */
 export { Service } from "./McBopomofo/Service";
+/** Keyboard layout and reading buffer for Mandarin phonetic composition. */
+export { BopomofoReadingBuffer, BopomofoKeyboardLayout } from "./Mandarin";


### PR DESCRIPTION
前陣子我寫了一篇關於 [Viterbi 的重構文章](https://then.tw/mcbopomofo-viterbi/)，文中有畫了一些選字的狀態圖，因為交給 AI 畫的效果不太理想，所以幾乎都是自己慢慢畫的，覺得很麻煩，因此突然想到可以寫一個繪製選字路徑圖的工具，幫助大家理解小麥注音的選字原理~

(PS. 我其實不知道要怎麼稱呼這種圖比較好，才叫它選字路徑圖XD)

<img src="https://github.com/user-attachments/assets/305f4c22-8539-4167-984a-33c7dd43179f" />

## 輸入格式

- `ㄓㄨˋ ㄧㄣ ㄕㄨ ㄖㄨˋ ㄈㄚˇ`
- `ㄓㄨˋ-ㄧㄣ-ㄕㄨ-ㄖㄨˋ-ㄈㄚˇ`
- `5j4 up gj bj4 z83`
- `5j4-up-gj-bj4-z83`

輸入框有實作成輸入法，直接輸入會是第一種形式；後三種因為英數或 `-` 的關係應該沒辦法打字出來，是複製貼上時才會用到。

## Mermaid

產生的 Mermaid 語法因為不知道要放在哪裡比較適合，所以目前只印在 console 中：

<img  src="https://github.com/user-attachments/assets/5a60cd59-dec5-4f43-940d-59279887de43" />
