### PR TITLE
Support keyboard layouts in graph input

### DIFF
--- a/output/example/index.html
+++ b/output/example/index.html
@@ -817,9 +817,24 @@
         </p>
         <ul>
           <li>每個節點代表音節之間的分隔位置 (例如 5 個音節有 V0 ~ V5)</li>
-          <li>有向邊代表從某個位置開始、跨越特定長度的候選詞彙與其權重 (對數機率)</li>
+          <li>有向邊代表從某個位置開始，跨越特定長度的候選詞彙與其權重 (對數機率)</li>
           <li>著色路徑代表最終被演算法選中的最佳結果</li>
         </ul>
+        <table>
+          <tr>
+            <td class="option_title">鍵盤配置：</td>
+            <td>
+              <select id="graph_layout" title="選字路徑圖鍵盤配置">
+                <option value="Standard">標準</option>
+                <option value="ETen">倚天</option>
+                <option value="Hsu">許式</option>
+                <option value="ETen26">倚天 26</option>
+                <option value="HanyuPinyin">漢語拼音</option>
+                <option value="IBM">IBM</option>
+              </select>
+            </td>
+          </tr>
+        </table>
       </div>
     </section>
 

--- a/output/example/index.js
+++ b/output/example/index.js
@@ -472,6 +472,31 @@ if (typeof document !== "undefined") {
     })();
 
     const { InputController, Service } = window.mcbopomofo;
+
+    function getGraphLayoutName() {
+      const graphLayout = $("graph_layout");
+      return graphLayout ? graphLayout.value : settingsManager.settings.layout;
+    }
+
+    function getActiveLayout() {
+      const { BopomofoKeyboardLayout } = window.mcbopomofo;
+      const name = getGraphLayoutName() || "Standard";
+      switch (name) {
+        case "ETen":
+          return BopomofoKeyboardLayout.ETenLayout;
+        case "Hsu":
+          return BopomofoKeyboardLayout.HsuLayout;
+        case "ETen26":
+          return BopomofoKeyboardLayout.ETen26Layout;
+        case "HanyuPinyin":
+          return BopomofoKeyboardLayout.HanyuPinyinLayout;
+        case "IBM":
+          return BopomofoKeyboardLayout.IBMLayout;
+        default:
+          return BopomofoKeyboardLayout.StandardLayout;
+      }
+    }
+
     const controller = (() => {
       const controller = new InputController(ui);
       controller.setUserVerticalCandidates(true);
@@ -647,11 +672,12 @@ if (typeof document !== "undefined") {
           return;
         }
 
-        const graphString = that.service.generateMermaidGraph(text);
+        const layout = getActiveLayout();
+        const graphString = that.service.generateMermaidGraph(text, layout);
         container.innerHTML = graphString;
         container.removeAttribute("data-processed");
 
-        const walkResult = that.service.getWalkResult(text);
+        const walkResult = that.service.getWalkResult(text, layout);
         if (resultRow && resultText && resultScore) {
           resultText.value = walkResult.text;
           resultScore.value = `${walkResult.score.toFixed(2)}`;
@@ -672,12 +698,68 @@ if (typeof document !== "undefined") {
         }
       };
 
+      function getGraphSvgBounds(svg) {
+        let x = 0;
+        let y = 0;
+        let width = 800;
+        let height = 600;
+
+        try {
+          const bbox = svg.getBBox();
+          if (bbox.width > 0 && bbox.height > 0) {
+            x = bbox.x;
+            y = bbox.y;
+            width = bbox.width;
+            height = bbox.height;
+          } else if (svg.viewBox && svg.viewBox.baseVal && svg.viewBox.baseVal.width > 0) {
+            x = svg.viewBox.baseVal.x;
+            y = svg.viewBox.baseVal.y;
+            width = svg.viewBox.baseVal.width;
+            height = svg.viewBox.baseVal.height;
+          } else {
+            const rect = svg.getBoundingClientRect();
+            width = rect.width || width;
+            height = rect.height || height;
+          }
+        } catch (e) {
+          console.warn("Could not read SVG content bounds, using rendered dimensions.", e);
+          const rect = svg.getBoundingClientRect();
+          width = rect.width || width;
+          height = rect.height || height;
+        }
+
+        return { x, y, width, height };
+      }
+
+      function cloneGraphSvgForExport(svg, scale = 1) {
+        const bounds = getGraphSvgBounds(svg);
+        const padding = 16;
+        const paddedX = bounds.x - padding;
+        const paddedY = bounds.y - padding;
+        const paddedWidth = bounds.width + padding * 2;
+        const paddedHeight = bounds.height + padding * 2;
+        const exportWidth = Math.ceil(paddedWidth * scale);
+        const exportHeight = Math.ceil(paddedHeight * scale);
+        const clonedSvg = svg.cloneNode(true);
+        clonedSvg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+        clonedSvg.setAttribute(
+          "viewBox",
+          `${paddedX} ${paddedY} ${paddedWidth} ${paddedHeight}`
+        );
+        clonedSvg.setAttribute("width", `${exportWidth}`);
+        clonedSvg.setAttribute("height", `${exportHeight}`);
+        clonedSvg.removeAttribute("style");
+
+        return { svg: clonedSvg, width: exportWidth, height: exportHeight };
+      }
+
       that.downloadGraphSVG = () => {
         const container = $("mermaid_graph_output");
         const svg = container.querySelector("svg");
         if (!svg) return;
 
-        const svgData = new XMLSerializer().serializeToString(svg);
+        const exportSvg = cloneGraphSvgForExport(svg);
+        const svgData = new XMLSerializer().serializeToString(exportSvg.svg);
         const svgBlob = new Blob([svgData], {
           type: "image/svg+xml;charset=utf-8",
         });
@@ -696,48 +778,18 @@ if (typeof document !== "undefined") {
         const svg = container.querySelector("svg");
         if (!svg) return;
 
-        let svgData = new XMLSerializer().serializeToString(svg);
-        
-        // Ensure SVG namespace is present
-        if (!svgData.match(/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/)) {
-          svgData = svgData.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
-        }
-
+        const exportSvg = cloneGraphSvgForExport(svg, 4);
+        const svgData = new XMLSerializer().serializeToString(exportSvg.svg);
         const canvas = document.createElement("canvas");
         const ctx = canvas.getContext("2d");
         const img = new Image();
-        
-        // Some browsers require base64 for SVG containing foreignObjects to render in canvas
-        const encodedData = encodeURIComponent(svgData);
-        img.src = "data:image/svg+xml;charset=utf-8," + encodedData;
 
         img.onload = () => {
-          let width = 800;
-          let height = 600;
-          
-          try {
-            if (svg.viewBox && svg.viewBox.baseVal && svg.viewBox.baseVal.width > 0) {
-              width = svg.viewBox.baseVal.width;
-              height = svg.viewBox.baseVal.height;
-            } else {
-              const bbox = svg.getBoundingClientRect();
-              width = bbox.width;
-              height = bbox.height;
-            }
-          } catch (e) {
-            console.warn("Could not read SVG dimensions, using bounding client rect.", e);
-            const bbox = svg.getBoundingClientRect();
-            width = bbox.width || 800;
-            height = bbox.height || 600;
-          }
-
-          const scale = 2;
-          canvas.width = width * scale;
-          canvas.height = height * scale;
+          canvas.width = exportSvg.width;
+          canvas.height = exportSvg.height;
           ctx.fillStyle = "white";
           ctx.fillRect(0, 0, canvas.width, canvas.height);
-          ctx.scale(scale, scale);
-          ctx.drawImage(img, 0, 0, width, height);
+          ctx.drawImage(img, 0, 0, exportSvg.width, exportSvg.height);
 
           try {
             const pngUrl = canvas.toDataURL("image/png");
@@ -755,6 +807,10 @@ if (typeof document !== "undefined") {
         img.onerror = (e) => {
           console.error("Failed to load SVG into Image object.", e);
         };
+
+        // Some browsers require percent encoding for SVG data URLs before canvas rendering.
+        const encodedData = encodeURIComponent(svgData);
+        img.src = "data:image/svg+xml;charset=utf-8," + encodedData;
       };
 
       return that;
@@ -852,6 +908,7 @@ if (typeof document !== "undefined") {
         applySelectSetting("layout", settings.layout, (value) =>
           controller.setKeyboardLayout(value),
         );
+        applySelectSetting("graph_layout", settings.layout, () => undefined);
         applySelectSetting("keys", settings.candidate_keys, (value) =>
           controller.setCandidateKeys(value),
         );
@@ -1255,12 +1312,27 @@ if (typeof document !== "undefined") {
         controller.setKeyboardLayout(value);
         settingsManager.settings.layout = value;
         settingsManager.saveSettings();
+        setSelectValue("graph_layout", value);
         screenKeyboard.loadLayout();
         focusElement("text_area");
       };
 
       $("layout").onblur = (event) => {
         focusElement("text_area");
+      };
+
+      $("graph_layout").onchange = (event) => {
+        const value = getValue("graph_layout");
+        controller.setKeyboardLayout(value);
+        settingsManager.settings.layout = value;
+        settingsManager.saveSettings();
+        setSelectValue("layout", value);
+        screenKeyboard.loadLayout();
+        focusElement("feature_graph_text_area");
+      };
+
+      $("graph_layout").onblur = (event) => {
+        focusElement("feature_graph_text_area");
       };
 
       $("keys").onchange = (event) => {
@@ -1534,27 +1606,6 @@ if (typeof document !== "undefined") {
           // Snapshot of text that came after selectionEnd when composition began.
           // Kept separate from lastValue so a selection range is replaced, not preserved.
           let lastAfter = "";
-
-          function getActiveLayout() {
-            const { BopomofoKeyboardLayout } = window.mcbopomofo;
-            const name = settingsManager.settings.layout || "Standard";
-            switch (name) {
-              case "Standard":
-                return BopomofoKeyboardLayout.StandardLayout;
-              case "ETen":
-                return BopomofoKeyboardLayout.ETenLayout;
-              case "Hsu":
-                return BopomofoKeyboardLayout.HsuLayout;
-              case "ETen26":
-                return BopomofoKeyboardLayout.ETen26Layout;
-              case "HanyuPinyin":
-                return BopomofoKeyboardLayout.HanyuPinyinLayout;
-              case "IBM":
-                return BopomofoKeyboardLayout.IBMLayout;
-              default:
-                return BopomofoKeyboardLayout.StandardLayout;
-            }
-          }
 
           function getGraphReadingBuffer() {
             const { BopomofoReadingBuffer } = window.mcbopomofo;

--- a/src/Gramambular2/ReadingGrid.test.ts
+++ b/src/Gramambular2/ReadingGrid.test.ts
@@ -76,6 +76,19 @@ describe("ReadingGrid", () => {
     expect(grid.cursor).toBe(2);
   });
 
+  it("should not expose mutable internal spans", () => {
+    const mockLM = new MockLanguageModel();
+    const grid = new ReadingGrid(mockLM);
+    grid.insertReading("testReading");
+
+    const exposedSpans = grid.spans as Span[];
+    exposedSpans.length = 0;
+    grid.spans[0].clear();
+
+    expect(grid.spans.length).toBe(1);
+    expect(grid.walk().valuesAsStrings()).toEqual(["testValue"]);
+  });
+
   it("should remove the reading before the cursor", () => {
     const mockLM = new MockLanguageModel();
     const grid = new ReadingGrid(mockLM);

--- a/src/Gramambular2/ReadingGrid.ts
+++ b/src/Gramambular2/ReadingGrid.ts
@@ -92,8 +92,8 @@ export class ReadingGrid {
   /**
    * The spans in the grid.
    */
-  get spans(): Span[] {
-    return this.spans_;
+  get spans(): readonly Span[] {
+    return this.spans_.map((span) => span.clone());
   }
 
   /**
@@ -639,6 +639,18 @@ export class Node {
   }
 
   /**
+   * Returns a copy of the node state.
+   */
+  clone(): Node {
+    const node = new Node(this.reading, this.spanningLength, [
+      ...this.unigrams,
+    ]);
+    node.selectedIndex_ = this.selectedIndex_;
+    node.overrideType_ = this.overrideType_;
+    return node;
+  }
+
+  /**
    * A sufficiently high score to cause the walk to go through an overriding
    * node. Although this can be 0, setting it to a positive value has the
    * desirable side effect that it reduces the competition of "free-floating"
@@ -831,6 +843,16 @@ export class Span {
   nodeOf(length: number): Node | undefined {
     // assert(length > 0 && length <= ReadingGrid.kMaximumSpanLength);
     return this.nodes_[length - 1];
+  }
+
+  /**
+   * Returns a copy of the span state.
+   */
+  clone(): Span {
+    const span = new Span();
+    span.nodes_ = this.nodes_.map((node) => node?.clone());
+    span.maxLength_ = this.maxLength_;
+    return span;
   }
 }
 

--- a/src/McBopomofo/Service.test.ts
+++ b/src/McBopomofo/Service.test.ts
@@ -1,3 +1,4 @@
+import { BopomofoKeyboardLayout } from "../Mandarin";
 import { Service } from "./Service";
 
 describe("Service", () => {
@@ -352,6 +353,78 @@ describe("Service", () => {
     expect(result).toContain("V5");
     expect(result).toContain("classDef selected");
     expect(result).toContain("linkStyle");
+  });
+
+  test.each([
+    ["Standard", "186", BopomofoKeyboardLayout.StandardLayout],
+    ["ETen", "ba2", BopomofoKeyboardLayout.ETenLayout],
+    ["Hsu", "byd", BopomofoKeyboardLayout.HsuLayout],
+    ["ETen26", "baf", BopomofoKeyboardLayout.ETen26Layout],
+    ["Hanyu Pinyin", "ba2", BopomofoKeyboardLayout.HanyuPinyinLayout],
+    ["IBM", "1fm", BopomofoKeyboardLayout.IBMLayout],
+  ])("graph key sequence input supports %s layout", (_name, input, layout) => {
+    const service = new Service();
+    const expected = service.getWalkResult("ㄅㄚˊ");
+    const result = service.getWalkResult(input, layout);
+
+    expect(result.text).toBe(expected.text);
+    expect(result.score).toBe(expected.score);
+  });
+
+  test.each([
+    ["Standard . key as ㄡ", "2.", BopomofoKeyboardLayout.StandardLayout, "ㄉㄡ"],
+    ["Standard / key as ㄥ", "2/", BopomofoKeyboardLayout.StandardLayout, "ㄉㄥ"],
+    ["Standard - key as ㄦ", "-", BopomofoKeyboardLayout.StandardLayout, "ㄦ"],
+    ["ETen . key as ㄔ", ".a", BopomofoKeyboardLayout.ETenLayout, "ㄔㄚ"],
+    ["ETen / key as ㄕ", "/a", BopomofoKeyboardLayout.ETenLayout, "ㄕㄚ"],
+    ["ETen - key as ㄥ", "d-", BopomofoKeyboardLayout.ETenLayout, "ㄉㄥ"],
+    ["IBM - key as ㄏ", "-;,", BopomofoKeyboardLayout.IBMLayout, "ㄏㄠˇ"],
+    ["IBM . key as ˋ", "-;.", BopomofoKeyboardLayout.IBMLayout, "ㄏㄠˋ"],
+    ["IBM / key as ˙", "1;/", BopomofoKeyboardLayout.IBMLayout, "ㄅㄠ˙"],
+  ])("graph key sequence input maps symbol keys: %s", (_name, input, layout, bpmf) => {
+    const service = new Service();
+    const expected = service.getWalkResult(bpmf);
+    const result = service.getWalkResult(input, layout);
+
+    expect(result.text).toBe(expected.text);
+    expect(result.score).toBe(expected.score);
+  });
+
+  test.each([
+    ["Hsu", "jxj-en", BopomofoKeyboardLayout.HsuLayout, "ㄓㄨˋ ㄧㄣ"],
+    ["ETen26", "gen-tem", BopomofoKeyboardLayout.ETen26Layout, "ㄐㄧㄣ ㄊㄧㄢ"],
+    ["Hanyu Pinyin", "zhu4-in", BopomofoKeyboardLayout.HanyuPinyinLayout, "ㄓㄨˋ ㄧㄣ"],
+  ])("graph key sequence input treats hyphen as a separator for %s layout", (
+    _name,
+    input,
+    layout,
+    bpmf
+  ) => {
+    const service = new Service();
+    const expected = service.getWalkResult(bpmf);
+    const result = service.getWalkResult(input, layout);
+
+    expect(result.text).toBe(expected.text);
+    expect(result.score).toBe(expected.score);
+  });
+
+  test("graph Bopomofo input still accepts hyphen-separated syllables", () => {
+    const service = new Service();
+    const result = service.getWalkResult("ㄓㄨˋ-ㄧㄣ");
+
+    expect(result.text).toBe("注音");
+    expect(result.score).toBeLessThan(0);
+  });
+
+  test("graph key sequence input can use Hanyu Pinyin syllables", () => {
+    const service = new Service();
+    const result = service.getWalkResult(
+      "zhu4 in",
+      BopomofoKeyboardLayout.HanyuPinyinLayout
+    );
+
+    expect(result.text).toBe("注音");
+    expect(result.score).toBeLessThan(0);
   });
 
   test("getWalkResult returns non-empty text for valid Bopomofo input", () => {

--- a/src/McBopomofo/Service.ts
+++ b/src/McBopomofo/Service.ts
@@ -512,27 +512,22 @@ export class Service {
    * Parses `input` into Bopomofo syllables, builds a temporary ReadingGrid,
    * and returns the grid together with the Viterbi walk result.
    * Shared by `generateMermaidGraph` and `getWalkResult`.
+   * @param keyboardLayout The layout used to parse keyboard-sequence tokens.
    */
   private buildAndWalk(
-    input: string
+    input: string,
+    keyboardLayout: BopomofoKeyboardLayout = BopomofoKeyboardLayout.StandardLayout
   ): { walkedNodes: ReturnType<ReadingGrid["walk"]>["nodes"]; tempGrid: ReadingGrid } | null {
-    const tokens = input.trim().split(/[\s-]+/).filter((t) => t.length > 0);
-    const layout = BopomofoKeyboardLayout.StandardLayout;
+    const tokens = this.tokenizeWalkInput(input, keyboardLayout);
     const syllables: string[] = [];
 
     for (const token of tokens) {
-      let isBpmf = false;
-      for (let i = 0; i < token.length; i++) {
-        if (BopomofoCharacterMap.sharedInstance.characterToComponent.has(token.charAt(i))) {
-          isBpmf = true;
-          break;
-        }
-      }
+      const isBpmf = this.containsBopomofoComponent(token);
       if (isBpmf) {
         const syllable = MandarinBopomofoSyllable.FromComposedString(token);
         syllables.push(!syllable.isEmpty ? syllable.composedString : token);
       } else {
-        const syllable = layout.syllableFromKeySequence(token);
+        const syllable = this.syllableFromKeyboardSequence(token, keyboardLayout);
         syllables.push(!syllable.isEmpty ? syllable.composedString : token);
       }
     }
@@ -548,12 +543,71 @@ export class Service {
     return { walkedNodes: walkResult.nodes, tempGrid };
   }
 
+  private tokenizeWalkInput(
+    input: string,
+    keyboardLayout: BopomofoKeyboardLayout
+  ): string[] {
+    const tokens: string[] = [];
+    const rawTokens = input.trim().split(/\s+/).filter((t) => t.length > 0);
+
+    for (const rawToken of rawTokens) {
+      // Hyphen is a reading separator for Bopomofo and Hanyu Pinyin graph input,
+      // but it is also a real key in layouts such as Standard, ETen, and IBM.
+      // Split only when the active keyboard layout does not use hyphen as a key.
+      const shouldSplitHyphen =
+        keyboardLayout === BopomofoKeyboardLayout.HanyuPinyinLayout ||
+        this.containsBopomofoComponent(rawToken) ||
+        !this.keyboardLayoutUsesHyphenKey(keyboardLayout);
+      if (shouldSplitHyphen) {
+        tokens.push(...rawToken.split(/-+/).filter((t) => t.length > 0));
+      } else {
+        tokens.push(rawToken);
+      }
+    }
+
+    return tokens;
+  }
+
+  private keyboardLayoutUsesHyphenKey(
+    keyboardLayout: BopomofoKeyboardLayout
+  ): boolean {
+    return !keyboardLayout.syllableFromKeySequence("-").isEmpty;
+  }
+
+  private containsBopomofoComponent(token: string): boolean {
+    for (let i = 0; i < token.length; i++) {
+      if (
+        BopomofoCharacterMap.sharedInstance.characterToComponent.has(
+          token.charAt(i)
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private syllableFromKeyboardSequence(
+    token: string,
+    keyboardLayout: BopomofoKeyboardLayout
+  ): MandarinBopomofoSyllable {
+    if (keyboardLayout === BopomofoKeyboardLayout.HanyuPinyinLayout) {
+      return MandarinBopomofoSyllable.FromHanyuPinyin(token);
+    }
+    return keyboardLayout.syllableFromKeySequence(token);
+  }
+
   /**
    * Returns the Viterbi-selected text and its total log-probability score
    * for the given Bopomofo (or keyboard-sequence) input.
+   * @param input Bopomofo syllables or keyboard sequences.
+   * @param keyboardLayout The layout used to parse keyboard-sequence tokens.
    */
-  public getWalkResult(input: string): { text: string; score: number } {
-    const built = this.buildAndWalk(input);
+  public getWalkResult(
+    input: string,
+    keyboardLayout: BopomofoKeyboardLayout = BopomofoKeyboardLayout.StandardLayout
+  ): { text: string; score: number } {
+    const built = this.buildAndWalk(input, keyboardLayout);
     if (!built) return { text: "", score: 0 };
     const text = built.walkedNodes.map((n) => n.value).join("");
     const score = built.walkedNodes.reduce((acc, n) => acc + n.score, 0);
@@ -652,19 +706,26 @@ export class Service {
 
   /**
    * Generates a Mermaid graph representing candidate selections.
+   * @param input Bopomofo syllables or keyboard sequences.
+   * @param keyboardLayout The layout used to parse keyboard-sequence tokens.
    */
-  public generateMermaidGraph(input: string): string {
-    const built = this.buildAndWalk(input);
+  public generateMermaidGraph(
+    input: string,
+    keyboardLayout: BopomofoKeyboardLayout = BopomofoKeyboardLayout.StandardLayout
+  ): string {
+    const built = this.buildAndWalk(input, keyboardLayout);
     if (!built) return "graph LR\n  empty((Empty))";
     const { walkedNodes, tempGrid } = built;
 
-    const walkedSegments: { start: number; end: number; node: any }[] = [];
+    const walkedSegments: {
+      start: number;
+      end: number;
+    }[] = [];
     let currentIdx = 0;
     for (const walkedNode of walkedNodes) {
       walkedSegments.push({
         start: currentIdx,
         end: currentIdx + walkedNode.spanningLength,
-        node: walkedNode,
       });
       currentIdx += walkedNode.spanningLength;
     }
@@ -682,14 +743,15 @@ export class Service {
     }
     const edges: Edge[] = [];
 
+    const spans = tempGrid.spans;
     for (let i = 0; i < tempGrid.length; i++) {
-      const span = tempGrid.spans[i];
+      const span = spans[i];
       for (let len = 1; len <= span.maxLength; len++) {
         const node = span.nodeOf(len);
         if (!node) continue;
 
         const isWalked = walkedSegments.some(
-          (seg) => seg.start === i && seg.end === i + len && seg.node === node
+          (seg) => seg.start === i && seg.end === i + len
         );
 
         const value = node.value;
@@ -748,7 +810,6 @@ export class Service {
       mermaid += `\n  %% Highlight Link ${walkedLinkIndices.join(" & ")}\n`;
       mermaid += `  linkStyle ${walkedLinkIndices.join(",")} stroke:#e7000b,stroke-width:3px,fill:none;\n`;
     }
-    console.log(mermaid);
     return mermaid;
   }
 }


### PR DESCRIPTION
This PR is a follow-up to #618. After thinking it over, I agree that the keyboard layout issue pointed out by Gemini is valid, so I added the keyboard configuration. I also made some fixes for the low resolution of exported PNGs and the excessive white margins in SVG exports.

- Add keyboard layout support to the graph input.
- Let graph input parse Standard, ETen, Hsu, ETen26, Hanyu Pinyin, and IBM key sequences.
- Protect `ReadingGrid.spans` from external mutation by returning cloned span/node state.
- Improve SVG/PNG graph export sizing with padded SVG bounds.
- Add tests for layout-aware graph parsing, symbol keys, hyphen-separated input, and immutable exposed spans.

### SVG Before
<img width="500" src="https://github.com/user-attachments/assets/414d0723-541c-4b91-ba74-7f020b957c2d" />

### SVG After
<img width="500" src="https://github.com/user-attachments/assets/3e5d09cd-88ab-42e6-bf92-8d28f34d9445" />



