### PR TITLE
Potential fix for code scanning alert no. 14: Use of externally-controlled format string

### DIFF
--- a/output/example/webmcp.js
+++ b/output/example/webmcp.js
@@ -1331,7 +1331,7 @@ class WebMCP {
     _handleGetPrompt(message) {
         const {id, name, arguments: args} = message;
 
-        console.log(`Prompt request: ${name} with args:`, args);
+        console.log('Prompt request: %s with args: %o', name, args);
 
         if (!this.availablePrompts.has(name)) {
             this._sendMessage({


### PR DESCRIPTION
Potential fix for [https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/14](https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/14)

General fix: never let untrusted input become the log format string (the first argument). Use a constant format string and pass untrusted values as additional arguments (prefer `%s`/`%o` placeholders), or otherwise sanitize `%` in untrusted strings before interpolation.

Best minimal fix (no functionality change): update line 1334 in `output/example/webmcp.js` to use a static format string with placeholders, passing `name` and `args` as separate arguments. This preserves the same log content while preventing attacker-controlled format directives from being interpreted.

Change needed:
- File: `output/example/webmcp.js`
- Region: `_handleGetPrompt(message)` around current line 1334
- Replace:
  - ``console.log(`Prompt request: ${name} with args:`, args);``
- With:
  - `console.log('Prompt request: %s with args: %o', name, args);`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
