### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/output/pime/config_tool.py
+++ b/output/pime/config_tool.py
@@ -101,7 +101,7 @@ class OpenUserPhrasesHandler(BaseHandler):
             self.write(response)
         except Exception as e:
             print(e)
-            response = """{"return": false, "error":"%s"}""" % str(e)
+            response = """{"return": false, "error":"internal error"}"""
             self.write(response)
 
 
@@ -132,7 +132,7 @@ class UserPhrasesHandler(BaseHandler):
             self.write('{"return":true}')
         except Exception as e:
             print(e)
-            self.write('{"return":false, "error":"%s"}' % str(e))
+            self.write('{"return":false, "error":"internal error"}')
 
 
 class ExcludedPhrasesHandler(BaseHandler):
@@ -163,7 +163,7 @@ class ExcludedPhrasesHandler(BaseHandler):
             self.write('{"return":true}')
         except Exception as e:
             print(e)
-            self.write('{"return":false, "error":"%s"}' % str(e))
+            self.write('{"return":false, "error":"internal error"}')
 
 
 class ConfigHandler(BaseHandler):


### PR DESCRIPTION
Potential fix for [https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/9](https://github.com/openvanilla/McBopomofoWeb/security/code-scanning/9)

General fix: never return raw exception details to clients. Log exception details server-side, and return a generic error message in the HTTP response.

Best fix in this file: in the `except Exception as e:` blocks of:
- `OpenUserPhrasesHandler.get` (lines ~102–105),
- `UserPhrasesHandler.post` (lines ~133–135),
- `ExcludedPhrasesHandler.post` (lines ~164–166),

replace responses that interpolate `str(e)` with constant generic JSON errors like `{"return":false, "error":"internal error"}`. Keep `print(e)` for server-side diagnostics (or equivalent logging) so debugging remains possible without exposing internals.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
